### PR TITLE
Implement a mechanism for sending a MetaEvent from Statechart Code Bl…

### DIFF
--- a/sismic/interpreter/default.py
+++ b/sismic/interpreter/default.py
@@ -150,7 +150,7 @@ class Interpreter:
            exposed respectively through the ``source``, ``target`` and ``event`` attribute.
 
         The internal clock of all property statecharts will be synced with the one of the current interpreter.
-        As soon as a property statechart reaches a final state, a ``PropertyStatechartError`` will be raised, 
+        As soon as a property statechart reaches a final state, a ``PropertyStatechartError`` will be raised,
         implicitly meaning that the property expressed by the corresponding property statechart is not satisfied.
 
         :param statechart_or_interpreter: A property statechart or an interpreter of a property statechart.
@@ -607,10 +607,11 @@ class Interpreter:
 
         # Send events
         for event in sent_events:
-            self._raise_event(event)
-
-            # Notify properties
-            self._notify_properties('event sent', event=event)
+            if isinstance(event, InternalEvent):
+                self._raise_event(event)
+                self._notify_properties('event sent', event=event)
+            elif isinstance(event, MetaEvent):
+                self._notify_properties('meta event sent', event=event)
 
         return MicroStep(event=step.event, transition=step.transition,
                          entered_states=step.entered_states, exited_states=step.exited_states,

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -3,7 +3,7 @@ import pytest
 from sismic import code
 from sismic.code.python import FrozenContext
 from sismic.exceptions import CodeEvaluationError
-from sismic.interpreter import Event, InternalEvent
+from sismic.interpreter import Event, InternalEvent, MetaEvent
 
 
 def test_dummy_evaluator(mocker):
@@ -81,6 +81,10 @@ class TestPythonEvaluator:
         events = evaluator._execute_code('send("hello")')
         assert events == [InternalEvent('hello')]
 
+    def test_meta(self, evaluator):
+        events = evaluator._execute_code('meta("hello")')
+        assert events == [MetaEvent('hello')]
+
     def test_no_event_raised_by_preamble(self, interpreter, evaluator):
         interpreter.statechart.preamble = 'send("test")'
         with pytest.raises(CodeEvaluationError):
@@ -93,4 +97,3 @@ class TestPythonEvaluator:
     @pytest.mark.skip('http://stackoverflow.com/questions/32894942/listcomp-unable-to-access-locals-defined-in-code-called-by-exec-if-nested-in-fun')
     def test_access_outer_scope(self, evaluator):
         evaluator._execute_code('d = [x for x in range(10) if x!=a]', additional_context={'a': 1})
-

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -41,6 +41,16 @@ class TestInterpreterMetaEvents:
 
         assert MetaEvent('event sent', event=InternalEvent('test')) in [x[0][0] for x in property_statechart.queue.call_args_list]
 
+    def test_meta_event_sent(self, microwave, property_statechart):
+        # Add meta to a state
+        state = microwave.statechart.state_for('door closed')
+        state.on_entry = 'meta("test")'
+
+        microwave.execute()
+
+        assert MetaEvent('event sent', event=InternalEvent('test')) not in [x[0][0] for x in property_statechart.queue.call_args_list]
+        assert MetaEvent('meta event sent', event=MetaEvent('test')) in [x[0][0] for x in property_statechart.queue.call_args_list]
+
     def test_trace(self, microwave, property_statechart):
         microwave.queue(Event('door_opened'))
         microwave.execute()
@@ -82,4 +92,3 @@ class TestInterpreterMetaEvents:
 
         with pytest.raises(PropertyStatechartError):
             microwave.execute()
-


### PR DESCRIPTION
Hi,

this is a commit that helps support Distributed Statecharts. Please let me know
if you need any further details.

Tim.



Implement a mechanism for sending a MetaEvent from Statechart Code Blocks.

    meta("metadata", datum="foo", value="bar)

To support Distributed Statecharts, where one Statechart would like to
communicate Meta-Information to other Statecharts which are possibly
running as separate Systems (i.e running in other Processes, Containers
or Servers).

For Distributed Statecharts these MetaEvents are routed to "Adapters"
which implement the Property Statechart Interface. These Adapters are
attached to the Statechart Interpreter in the normal way. The
MetaEvents are intercepted by an Adapter and communicated to the other
Statecharts accordign to the methods defined in each particular Adapter.

The MetaEvents are not sent to the internal Event Queue and they should
not interfear with the existing operation of Property Statecharts as
these MetaEvents are identifed in Property Statecharts as
"meta event sent" rather than "event sent" (as seen when send() is used).