### PR TITLE
Implement a Default Transition for States.

### DIFF
--- a/sismic/interpreter/default.py
+++ b/sismic/interpreter/default.py
@@ -370,9 +370,16 @@ class Interpreter:
 
         # Select transitions with no event first
         for transition in self._statechart.transitions:
-            if (transition.event is None and transition.source in self._configuration and
+            if (transition.event is None and transition.default is None and transition.source in self._configuration and
                     (transition.guard is None or self._evaluator.evaluate_guard(transition))):
                 transitions.append(transition)
+
+        # If no transitions, see if there is a default.
+        if len(transitions) == 0:
+            for transition in self._statechart.transitions:
+                if (transition.default is not None and transition.source in self._configuration and
+                        (transition.guard is None or self._evaluator.evaluate_guard(transition))):
+                    transitions.append(transition)
 
         if len(transitions) > 0:
             return None, transitions
@@ -383,7 +390,7 @@ class Interpreter:
             return None, []
 
         for transition in self._statechart.transitions:
-            if (transition.event == getattr(event, 'name', None) and transition.source in self._configuration and
+            if (transition.event == getattr(event, 'name', None) and transition.default is None and transition.source in self._configuration and
                     (transition.guard is None or self._evaluator.evaluate_guard(transition, event))):
                 transitions.append(transition)
         return event, transitions

--- a/sismic/io/datadict.py
+++ b/sismic/io/datadict.py
@@ -71,6 +71,7 @@ def _import_transition_from_dict(state_name: str, transition_d: Mapping[str, Any
     """
     event = transition_d.get('event', None)
     guard = transition_d.get('guard', None)
+    default = transition_d.get('default', None)
     action = transition_d.get('action', None)
 
     transition = Transition(
@@ -78,6 +79,7 @@ def _import_transition_from_dict(state_name: str, transition_d: Mapping[str, Any
         transition_d.get('target', None),
         event.strip() if event else None,
         guard.strip() if guard else None,
+        default.strip() if default else None,
         action.strip() if action else None,
     )
 
@@ -203,7 +205,7 @@ def _export_state_to_dict(statechart: Statechart, state_name: str, ordered=True)
         data['contract'] = conditions
 
     if isinstance(state, TransitionStateMixin):
-        # event, guard, target, action
+        # event, guard, target, default, action
         transitions = statechart.transitions_from(cast(StateMixin, state).name)
         if len(transitions) > 0:
             data['transitions'] = []
@@ -216,6 +218,8 @@ def _export_state_to_dict(statechart: Statechart, state_name: str, ordered=True)
                     transition_data['guard'] = transition.guard
                 if transition.target:
                     transition_data['target'] = transition.target
+                if transition.default:
+                    transition_data['default'] = transition.default
                 if transition.action:
                     transition_data['action'] = transition.action
 

--- a/sismic/io/plantuml.py
+++ b/sismic/io/plantuml.py
@@ -197,6 +197,8 @@ class PlantUMLExporter:
             text.append(transition.event + ' ')
         if transition.guard:
             text.append('[{}] '.format(transition.guard))
+        if transition.default:
+            text.append('[(default)] ')
         if transition.action and self.transition_action:
             text.append('/ {}'.format(transition.action.replace('\n', '; ')))
 

--- a/sismic/io/yaml.py
+++ b/sismic/io/yaml.py
@@ -19,6 +19,7 @@ class SCHEMA:
         schema.Optional('event'): schema.Use(str),
         schema.Optional('guard'): schema.Use(str),
         schema.Optional('action'): schema.Use(str),
+        schema.Optional('default'): schema.Use(str),
         schema.Optional('contract'): [contract],
     }
 

--- a/sismic/model/elements.py
+++ b/sismic/model/elements.py
@@ -290,15 +290,17 @@ class Transition(ContractMixin):
     :param target: name of the target state (if transition is not internal)
     :param event: event name (if any)
     :param guard: condition as code (if any)
+    :param default: name of the target state (if no other transitions evaulate)
     :param action: action as code (if any)
     """
 
-    def __init__(self, source: str, target: str=None, event: str=None, guard: str=None, action: str=None) -> None:
+    def __init__(self, source: str, target: str=None, event: str=None, guard: str=None, default: str=None, action: str=None) -> None:
         ContractMixin.__init__(self)
         self._source = source
         self._target = target
         self.event = event
         self.guard = guard
+        self._default = default
         self.action = action
 
     @property
@@ -307,7 +309,13 @@ class Transition(ContractMixin):
 
     @property
     def target(self):
+        if self._default:
+            return self._default
         return self._target
+
+    @property
+    def default(self):
+        return self._default
 
     @property
     def internal(self):
@@ -332,6 +340,7 @@ class Transition(ContractMixin):
                 and self.event == other.event
                 and self.guard == other.guard
                 and self.action == other.action
+                and self.default == other.default
             )
         else:
             return NotImplemented

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,10 @@ def composite_statechart():
 def internal_statechart():
     return import_from_yaml(filepath='tests/yaml/internal.yaml')
 
+@pytest.fixture
+def default_transition_statechart():
+    return import_from_yaml(filepath='tests/yaml/default_transition.yaml')
+
 
 @pytest.fixture(params=['actions', 'composite', 'deep_history', 'final', 'infinite', 'internal',
                         'nested_parallel', 'nondeterministic', 'parallel', 'simple', 'timer'])

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -116,6 +116,25 @@ class TestInterpreterWithInternal:
         assert interpreter.final
 
 
+class TestInterpreterWithDefaultTransition:
+    @pytest.fixture
+    def interpreter(self, default_transition_statechart):
+        interpreter = Interpreter(default_transition_statechart)
+
+        # Stabilization
+        interpreter.execute_once()
+
+        return interpreter
+
+    def test_single_default_transition(self, interpreter):
+        interpreter.queue(Event('goto s2'))
+        assert interpreter.execute_once().entered_states == ['s2']
+        assert interpreter.execute_once().entered_states == ['s3']
+        assert interpreter.execute_once().entered_states == ['s3']
+        assert interpreter.execute_once().entered_states == ['final']
+        assert interpreter.final
+
+
 class TestInterpreterWithFinal:
     @pytest.fixture()
     def interpreter(self, final_statechart):

--- a/tests/yaml/default_transition.yaml
+++ b/tests/yaml/default_transition.yaml
@@ -1,0 +1,23 @@
+statechart:
+  name: default transition statechart
+  root state:
+    name: root
+    on entry: x = 0
+    initial: s1
+
+    states:
+      - name: s1
+        transitions:
+          - target: s2
+            event: goto s2
+      - name: s2
+        transitions:
+          - default: s3
+      - name: s3
+        transitions:
+          - target: s3
+            guard: x == 0
+            action: x += 1
+          - default: final
+      - name: final
+        type: final


### PR DESCRIPTION
Hello,

this is one other small idea that came out of my efforts last week with Sismic. We had a few situations where a Default Transition would be helpful, or at least, more to the point. The idea was to get a Statechart definition which looks like this:

```
- name: startup
  initial: get_remote_system_state
  states:
  - name: get_remote_system_state
    on entry: |
      rc = r.execute_command("system.state")
      notify('metadata', datum='system.state', value=rc)
    transitions:
    - target: running
      guard: rc == 5
    - target: starting
      guard: rc == 2 or rc == 3
    - target: final
      guard: rc == 0
    - default: startup
      action: sleep(0.1)
```


... where we are able to let unexpected or transitional/temporary return_values fall through to a default handler. I don't show it above, but to do this started to require some complex guard conditions and that was the motivation behind the Default Transition (aside from learning more about Sismic).

In any case, I will leave it to your discretion ... as its possible to solve this problem with Python code in the "on entry" section, and probably several other ways, there is no urgency behind this. Please let me know if you need any further details or input.

Tim.


# The original commit text:
===================
In cases where a State has no Transitions which evaluate, or
several guard conditions resulting in complexity, allow the
configuation of a Default Transition:

    - name: s3
      transitions:
        - target: s3
          guard: x == 0
        - default: final

The Default Transition is only taken if no other Transitions
evaluate and it is taken before considering any pending Events.