### PR TITLE
Add support for transition priority

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+ 
+ - (Added) Priority can be set for transitions (using *low*, *high* or any integer in yaml). transitions
+   are selected according to their priorities (still following eventless and inner-first/source state semantics).
+
+
 1.2.2 (2018-06-21)
 ------------------
 

--- a/docs/execution.rst
+++ b/docs/execution.rst
@@ -45,6 +45,9 @@ We decide to follow Rhapsody and to raise an error (in fact, a :py:exc:`~sismic.
 nondeterminism occur during the execution. Notice that this only concerns multiple transitions in the same
 composite state, not in parallel states.
 
+.. note:: Sismic allows to define priorities on transitions to address nondeterminism: transitions with 
+        higher priorities will be selected first for execution, ignoring transitions with lower priorities.
+
 When multiple transitions are triggered from within distinct parallel states, the situation is even more intricate.
 According to the Rhapsody implementation:
 

--- a/docs/format.rst
+++ b/docs/format.rst
@@ -222,7 +222,15 @@ Instead, it **must** either define an event or define a guard to determine when 
 Notice that such a transition does not trigger the *on entry* and *on exit* of its state, and can thus be used
 to model an *internal action*.
 
+Priorities can be set for transitions using the *priority* property. By default, all transitions 
+have a priority of 0. A priority can be any integer, or *low* (equivalent to -1) or *high* 
+(equivalent to 1). 
 
+.. note:: Transition priorities can be used to simulate default transitions or to fix non-determinism
+    when multiple transitions from a single state can be triggered at the same time. Notice that 
+    transition priorities are considered **after** the default semantics of Sismic (eventless
+    transitions first, and inner-first/source state first). 
+    
 
 Statechart examples
 *******************

--- a/sismic/io/datadict.py
+++ b/sismic/io/datadict.py
@@ -72,6 +72,12 @@ def _import_transition_from_dict(state_name: str, transition_d: Mapping[str, Any
     event = transition_d.get('event', None)
     guard = transition_d.get('guard', None)
     action = transition_d.get('action', None)
+    priority = transition_d.get('priority', None)
+    
+    if priority == 'low':
+        priority = Transition.LOW_PRIORITY
+    elif priority == 'high':
+        priority = Transition.HIGH_PRIORITY
 
     transition = Transition(
         state_name,
@@ -79,6 +85,7 @@ def _import_transition_from_dict(state_name: str, transition_d: Mapping[str, Any
         event.strip() if event else None,
         guard.strip() if guard else None,
         action.strip() if action else None,
+        priority,
     )
 
     # Preconditions, postconditions and invariants
@@ -218,6 +225,14 @@ def _export_state_to_dict(statechart: Statechart, state_name: str, ordered=True)
                     transition_data['target'] = transition.target
                 if transition.action:
                     transition_data['action'] = transition.action
+                if transition.priority != Transition.DEFAULT_PRIORITY:
+                    if transition.priority == Transition.LOW_PRIORITY:
+                        priority = 'low'
+                    elif transition.priority == Transition.HIGH_PRIORITY:
+                        priority = 'high'
+                    else:
+                        priority = transition.priority
+                    transition_data['priority'] = priority
 
                 preconditions = getattr(transition, 'preconditions', [])
                 postconditions = getattr(transition, 'postconditions', [])

--- a/sismic/io/plantuml.py
+++ b/sismic/io/plantuml.py
@@ -132,6 +132,8 @@ class PlantUMLExporter:
             if len(transitions) > 0:
                 for transition in transitions:
                     text = []
+                    if transition.priority != 0:
+                        text.append('{}:'.format(transition.priority))
                     if transition.event:
                         text.append('**{}** '.format(transition.event))
                     if transition.guard:
@@ -193,6 +195,8 @@ class PlantUMLExporter:
             target_name = self.state_id(target.name)
 
         text = []
+        if transition.priority != 0:
+            text.append('{}:'.format(transition.priority))
         if transition.event:
             text.append(transition.event + ' ')
         if transition.guard:

--- a/sismic/io/yaml.py
+++ b/sismic/io/yaml.py
@@ -20,6 +20,7 @@ class SCHEMA:
         schema.Optional('guard'): schema.Use(str),
         schema.Optional('action'): schema.Use(str),
         schema.Optional('contract'): [contract],
+        schema.Optional('priority'): schema.Or(schema.Use(int), 'high', 'low'),
     }
 
     state = dict()  # type: ignore

--- a/sismic/model/elements.py
+++ b/sismic/model/elements.py
@@ -291,15 +291,21 @@ class Transition(ContractMixin):
     :param event: event name (if any)
     :param guard: condition as code (if any)
     :param action: action as code (if any)
+    :param priority: priority (default to 0)
     """
 
-    def __init__(self, source: str, target: str=None, event: str=None, guard: str=None, action: str=None) -> None:
+    LOW_PRIORITY = -1
+    DEFAULT_PRIORITY = 0
+    HIGH_PRIORITY = 1
+
+    def __init__(self, source: str, target: str=None, event: str=None, guard: str=None, action: str=None, priority=None) -> None:
         ContractMixin.__init__(self)
         self._source = source
         self._target = target
         self.event = event
         self.guard = guard
         self.action = action
+        self.priority = 0 if priority is None else priority
 
     @property
     def source(self):
@@ -340,7 +346,13 @@ class Transition(ContractMixin):
         return 'Transition({!r}, {!r}, event={!r})'.format(self.source, self.target, self.event)
 
     def __str__(self):
-        return '{} -> {} [{}] -> {}'.format(self.source, self.event, self.guard, self.target if self.target else '')
+        return '{} -> {}{} [{}] -> {}'.format(
+            self.source,
+            '' if self.priority == 0 else '{}:'.format(self.priority), 
+            self.event, 
+            self.guard, 
+            self.target if self.target else ''
+        )
 
     def __hash__(self):
         return hash(self.source)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,12 @@ def internal_statechart():
     return import_from_yaml(filepath='tests/yaml/internal.yaml')
 
 
-@pytest.fixture(params=['actions', 'composite', 'deep_history', 'final', 'infinite', 'internal',
+@pytest.fixture
+def priority_statechart():
+    return import_from_yaml(filepath='tests/yaml/priority.yaml')
+
+
+@pytest.fixture(params=['actions', 'composite', 'deep_history', 'final', 'infinite', 'internal', 'priority',
                         'nested_parallel', 'nondeterministic', 'parallel', 'simple', 'timer'])
 def example_from_tests(request):
     return import_from_yaml(filepath=os.path.join('tests', 'yaml', request.param + '.yaml'))

--- a/tests/yaml/priority.yaml
+++ b/tests/yaml/priority.yaml
@@ -1,0 +1,26 @@
+statechart:
+  name: test priorities
+  root state:
+    name: root
+    initial: a
+    states:
+     - name: a
+       transitions:
+        - target: b
+          priority: high
+        - target: c
+          priority: low
+        - target: d
+          priority: low
+     - name: b
+       transitions:
+        - event: e
+          target: c
+          priority: 1
+        - event: e
+          target: d
+          priority: low
+        - target: a
+          priority: -2
+     - name: c
+     - name: d


### PR DESCRIPTION
This PR adds support for transition priority, allowing one to set a priority on transitions to deal with non-determinism when transitions are selected for execution. Transition priorities are considered after *classical* semantics (i.e. after eventless first and inner-first/source state semantics). 

Priorities are defined in YAML using the "priority" keyword. By default, all transitions have a priority of 0. Higher values mean higher priority, and lower values mean lower priority. Two constants are also available, namely "high" (=1) and "low" (=-1). 

This PR solves #68, as one can set a low priority on a transition to simulate the behaviour of a default transition.