### PR TITLE
Add an asynchronous runner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
    action is executed, making the two predicates more accurate when long-running actions are 
    executed when a state is entered. Similarly, ``idle`` is reset after the action of a transition
    is performed, not before.
+ - (Changed) Drop support for Python 3.4.
  - (Deprecated) ``helpers.run_in_background`` is deprecated, use ``helpers.AsyncRunner`` instead.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,12 @@ Unreleased
  - (Added) Priority can be set for transitions (using *low*, *high* or any integer in yaml). transitions
    are selected according to their priorities (still following eventless and inner-first/source state semantics).
  - (Added) A ``sismic.testing`` module containing some primitives to ease unit testing.
+ - (Added) An ``AsyncRunner`` in module ``helpers`` to asynchronously run an interpreter at regular interval.
  - (Fixed) State *on entry* time (used for ``idle`` and ``after``) is set after the *on entry* 
    action is executed, making the two predicates more accurate when long-running actions are 
    executed when a state is entered. Similarly, ``idle`` is reset after the action of a transition
    is performed, not before.
+ - (Deprecated) ``helpers.run_in_background`` is deprecated, use ``helpers.AsyncRunner`` instead.
 
 
 1.2.2 (2018-06-21)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,13 +7,13 @@ Unreleased
  - (Added) Priority can be set for transitions (using *low*, *high* or any integer in yaml). transitions
    are selected according to their priorities (still following eventless and inner-first/source state semantics).
  - (Added) A ``sismic.testing`` module containing some primitives to ease unit testing.
- - (Added) An ``AsyncRunner`` in module ``helpers`` to asynchronously run an interpreter at regular interval.
+ - (Added) An ``AsyncRunner`` in the newly added ``runner`` module to asynchronously run an interpreter at regular interval.
  - (Fixed) State *on entry* time (used for ``idle`` and ``after``) is set after the *on entry* 
    action is executed, making the two predicates more accurate when long-running actions are 
    executed when a state is entered. Similarly, ``idle`` is reset after the action of a transition
    is performed, not before.
  - (Changed) Drop support for Python 3.4.
- - (Deprecated) ``helpers.run_in_background`` is deprecated, use ``helpers.AsyncRunner`` instead.
+ - (Deprecated) ``helpers.run_in_background`` is deprecated, use ``runner.AsyncRunner`` instead.
 
 
 1.2.2 (2018-06-21)

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ More specifically, Sismic provides:
 - Runtime checking of behavioral properties expressed as statecharts
 - Built-in support for behavior-driven development
 - Support for communication between statecharts
+- Synchronous and asynchronous executions
 - Statechart visualization using `PlantUML <http://www.plantuml.com/plantuml>`__
 
 Some experimental features are also available as `feature branches <https://github.com/AlexandreDecan/sismic/issues?q=is%3Aopen+is%3Aissue+label%3A%22feature+branch%22>`__.

--- a/docs/api/runner.rst
+++ b/docs/api/runner.rst
@@ -1,0 +1,11 @@
+Module *runner*
+===============
+
+.. automodule:: sismic.runner
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+    :inherited-members:
+    :imported-members:
+
+

--- a/docs/execution.rst
+++ b/docs/execution.rst
@@ -303,6 +303,19 @@ that can be used to see what happens. In particular:
    the :py:meth:`~sismic.interpreter.Interpreter.bind` method of an interpreter (see :ref:`communication`).
 
 
+Asynchronous execution
+----------------------
+
+The calls to :py:meth:`~sismic.interpreter.Interpreter.execute` or :py:meth:`~sismic.interpreter.Interpreter.execute_once`
+are blocking calls, i.e. they are performed synchronously. To allow asynchronous execution of a statechart, one 
+has, e.g., to run the interpreter in a separate thread or to continuously loop over these calls. 
+
+Module :py:mod:`~sismic.helpers` contains an :py:class:`~sismic.helpers.AsyncRunner` that provides basic
+support for continuous asynchronous execution of statecharts:
+
+.. autoclass:: sismic.helpers.AsyncRunner
+    :noindex:
+    
 
 Anatomy of the interpreter
 --------------------------

--- a/docs/execution.rst
+++ b/docs/execution.rst
@@ -310,10 +310,10 @@ The calls to :py:meth:`~sismic.interpreter.Interpreter.execute` or :py:meth:`~si
 are blocking calls, i.e. they are performed synchronously. To allow asynchronous execution of a statechart, one 
 has, e.g., to run the interpreter in a separate thread or to continuously loop over these calls. 
 
-Module :py:mod:`~sismic.helpers` contains an :py:class:`~sismic.helpers.AsyncRunner` that provides basic
+Module :py:mod:`~sismic.runner` contains an :py:class:`~sismic.runner.AsyncRunner` that provides basic
 support for continuous asynchronous execution of statecharts:
 
-.. autoclass:: sismic.helpers.AsyncRunner
+.. autoclass:: sismic.runner.AsyncRunner
     :noindex:
     
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ Sismic provides the following features:
 - Runtime checking of behavioral properties expressed as statecharts
 - Built-in support for behavior-driven development
 - Support for communication between statecharts
+- Synchronous and asynchronous executions
 - Statechart visualization using `PlantUML <http://www.plantuml.com/plantuml>`__
 
 Some experimental features are also available as `feature branches <https://github.com/AlexandreDecan/sismic/issues?q=is%3Aopen+is%3Aissue+label%3A%22feature+branch%22>`__.

--- a/sismic/helpers.py
+++ b/sismic/helpers.py
@@ -1,12 +1,15 @@
 import threading
+import time
+import warnings
+
 from collections import Counter
 from functools import wraps
-from typing import Any, Callable, List, Mapping
+from typing import Any, Callable, List, Mapping, Optional
 
 from .interpreter import Interpreter
 from .model import MacroStep
 
-__all__ = ['log_trace', 'run_in_background', 'coverage_from_trace']
+__all__ = ['log_trace', 'run_in_background', 'AsyncRunner', 'coverage_from_trace']
 
 
 def log_trace(interpreter: Interpreter) -> List[MacroStep]:
@@ -29,42 +32,6 @@ def log_trace(interpreter: Interpreter) -> List[MacroStep]:
 
     interpreter.execute_once = new_func  # type: ignore
     return trace
-
-
-def run_in_background(interpreter: Interpreter,
-                      delay: float=0.05,
-                      callback: Callable[[List[MacroStep]], Any]=None) -> threading.Thread:
-    """
-    Run given interpreter in background. The time is updated according to
-    *time.time() - starttime*. The interpreter is ran until it reaches a final configuration.
-    You can manually stop the thread using the added *stop* of the returned Thread object.
-    This is for convenience only and should be avoided, because a call to *stop* puts the interpreter in
-    an empty (and thus final) configuration, without properly leaving the active states.
-
-    :param interpreter: an interpreter
-    :param delay: delay between each call to *execute()*
-    :param callback: a function that accepts the result of *execute*.
-    :return: started thread (instance of *threading.Thread*)
-    """
-    import time
-
-    def _task():
-        starttime = time.time()
-        while not interpreter.final:
-            interpreter.time = time.time() - starttime
-            steps = interpreter.execute()
-            if callback:
-                callback(steps)
-            time.sleep(delay)
-    thread = threading.Thread(target=_task)
-
-    def stop_thread():
-        interpreter._configuration = set()
-
-    thread.stop = stop_thread  # type: ignore
-
-    thread.start()
-    return thread
 
 
 def coverage_from_trace(trace: List[MacroStep]) -> Mapping[str, Counter]:
@@ -91,3 +58,123 @@ def coverage_from_trace(trace: List[MacroStep]) -> Mapping[str, Counter]:
         'exited states': Counter(exited_states),
         'processed transitions': Counter(processed_transitions)
     }
+
+
+# TODO: Test
+class AsyncRunner:
+    """
+    An asynchronous runner that repeatedly call the `execute` method of an 
+    interpreter. 
+
+    The execution can be controlled with the `start` and `stop` methods.
+    
+    The runner tries to call `execute` every `interval` amount
+    of time, assuming that a call to `execute` takes less than `interval`
+    amount of time. The runner stops as soon as the underlying interpreter 
+    reaches a final configuration.
+
+    Methods `before_execute` and `after_execute` are hooks that are called
+    right before and right after the call to underlying interpreter's 
+    `execute()` method. They are meant to be overridden as by default, they
+    do nothing. 
+
+    :param interpreter: interpreter instance to run.
+    :param interval: interval between two calls to `execute`
+    """
+    def __init__(self, interpreter: Interpreter, interval: float=0.05) -> None:
+        self._running = threading.Event()
+        self.interpreter = interpreter
+        self.interval = interval
+        self._thread = None
+
+    def start(self):
+        """
+        Start the execution.
+        """
+        self._running.set()
+        self._run()
+
+    def stop(self):
+        """
+        Stop the execution.
+        """
+        self._running.clear()
+        if self._thread is not None:
+            self._thread.cancel()
+
+    def wait(self):
+        """
+        Wait for the execution.
+        """
+        # TODO: Not working, don't know why!
+        if self._thread is not None:
+            self._thread.join()
+
+    def before_execute(self):
+        """
+        Called before each call to `execute()`. 
+        """
+        pass
+
+    def after_execute(self, steps: Optional[MacroStep]):
+        """
+        Called after each call to `execute()` with the resulting steps.
+
+        :return: Steps returned by `execute()`.
+        """
+        pass
+
+    def _run(self):
+        starttime = time.time()
+        
+        self.before_execute()
+        steps = self.interpreter.execute()
+        self.after_execute(steps)
+
+        # TODO: Not thread-safe!!!
+        if self.interpreter.final:
+            self.stop()
+
+        if self._running.is_set():
+            elapsed = time.time() - starttime
+
+            self._thread = threading.Timer(max(0, self.interval - elapsed), self._run)
+            self._thread.start()
+
+
+def run_in_background(interpreter: Interpreter,
+                      delay: float=0.05,
+                      callback: Callable[[List[MacroStep]], Any]=None) -> threading.Thread:
+    """
+    Run given interpreter in background. The time is updated according to
+    *time.time() - starttime*. The interpreter is ran until it reaches a final configuration.
+    You can manually stop the thread using the added *stop* of the returned Thread object.
+    This is for convenience only and should be avoided, because a call to *stop* puts the interpreter in
+    an empty (and thus final) configuration, without properly leaving the active states.
+
+    :param interpreter: an interpreter
+    :param delay: delay between each call to *execute()*
+    :param callback: a function that accepts the result of *execute*.
+    :return: started thread (instance of *threading.Thread*)
+    :deprecated: since 1.3.0.
+    """
+    warnings.warn('Deprecated since 1.3.0. Use AsyncRunner instead.', DeprecationWarning)
+
+    def _task():
+        starttime = time.time()
+        while not interpreter.final:
+            interpreter.time = time.time() - starttime
+            steps = interpreter.execute()
+            if callback:
+                callback(steps)
+            time.sleep(delay)
+    thread = threading.Thread(target=_task)
+
+    def stop_thread():
+        interpreter._configuration = set()
+
+    thread.stop = stop_thread  # type: ignore
+
+    thread.start()
+    return thread
+

--- a/sismic/runner/__init__.py
+++ b/sismic/runner/__init__.py
@@ -1,0 +1,4 @@
+from .runner import AsyncRunner
+
+
+__all__ = ['AsyncRunner']

--- a/sismic/runner/runner.py
+++ b/sismic/runner/runner.py
@@ -1,0 +1,161 @@
+import time 
+import threading
+
+from typing import List
+
+from ..interpreter import Interpreter
+from ..model import MacroStep
+
+
+__all__ = ['AsyncRunner']
+
+
+class AsyncRunner:
+    """
+    An asynchronous runner that repeatedly execute given interpreter.
+
+    The runner tries to call its `execute` method every `interval` seconds, assuming 
+    that a call to interpreter `execute` method takes less time than `interval`. 
+    If not, subsequent call is queued and will occur as soon as possible with
+    no delay. The runner stops as soon as the underlying interpreter reaches 
+    a final configuration.
+
+    The execution must be started with the `start` method, and can be (definitively)
+    stopped with the `stop` method. An execution can be temporarily suspended 
+    using the `pause` and `unpause` methods. A call to `wait` blocks until 
+    the statechart reaches a final configuration. 
+
+    The current state of a runner can be obtained using its `running` and 
+    `paused` properties.
+
+    While this runner can be used "as is", it was designed to be subclassed and 
+    as such, proposes several hooks to control the execution and additional 
+    behaviours:
+
+     - before_run: called (only once !) when the runner is started.
+     - after_run: called (only once !) when the interpreter reaches a final configuration.
+       configuration of the underlying interpreter is reached. 
+     - execute: called at each step of the run. By default, call the `execute()`
+       method of the underlying interpreter. 
+     - before_execute: called right before the call to `execute()`;
+     - after_execute: called right after the call to `execute()`.
+       This method is called with the returned value of `execute()`.
+       
+    :param interpreter: interpreter instance to run.
+    :param interval: interval between two calls to `execute`
+    """
+    def __init__(self, interpreter: Interpreter, interval: float=0.1) -> None:
+        self._unpaused = threading.Event()
+        self._stop = threading.Event()
+
+        self.interpreter = interpreter
+        self.interval = interval
+        self._thread = threading.Thread(target=self._run)
+
+    @property
+    def running(self):
+        """
+        Holds if execution is currently running (event if it's paused).
+        """
+        return self._thread.is_alive()
+
+    @property
+    def paused(self):
+        """
+        Holds if execution is running but paused.
+        """
+        return self.running and not self._unpaused.is_set()
+
+    def start(self):
+        """
+        Start the execution.
+        """
+        if self._stop.is_set():
+            raise RuntimeError('Cannot restart a stopped runner.')
+        elif self._thread.isAlive():
+            raise RuntimeError('Runner is already started')
+        else:
+            self._unpaused.set()
+            self._thread.start()
+        
+    def stop(self):
+        """
+        Stop the execution.
+        """
+        self._unpaused.set()
+        self._stop.set()
+        self.wait()
+    
+    def pause(self):
+        """
+        Pause the execution.
+        """
+        self._unpaused.clear()
+
+    def unpause(self):
+        """
+        Unpause the execution.
+        """
+        self._unpaused.set()
+
+    def wait(self):
+        """
+        Wait for the execution to finish.
+        """
+        if self._thread.isAlive():
+            self._thread.join()
+
+    def execute(self) -> List[MacroStep]:
+        """
+        Called each time the interpreter has to be executed.
+        """
+        return self.interpreter.execute()
+
+    def before_execute(self):
+        """
+        Called before each call to `execute()`. 
+        """
+        pass
+
+    def after_execute(self, steps: List[MacroStep]):
+        """
+        Called after each call to self.execute().
+        Receives the return value of self.execute().
+
+        :param steps: List of macrosteps returned by self.execute()
+        """
+        pass
+
+    def before_run(self):
+        """
+        Called before running the execution.
+        """
+        pass
+
+    def after_run(self):
+        """
+        Called after a final configuration is reached.
+        """
+        pass
+
+    def _run(self):
+        self.before_run()
+
+        while not self.interpreter.final and not self._stop.is_set():
+            self._unpaused.wait()
+            
+            starttime = time.time()
+            self.before_execute()
+            r = self.execute()
+            self.after_execute(r)
+
+            elapsed = time.time() - starttime
+            time.sleep(max(0, self.interval - elapsed))
+
+        # Ensure that self._stop is set if self.interpreter.final holds
+        self._stop.set()
+
+        self.after_run()
+
+    def __del__(self):
+        self.stop()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,146 @@
+import pytest
+
+from time import sleep 
+
+from sismic.runner import AsyncRunner
+from sismic.interpreter import Interpreter
+
+
+class TestAsyncRunner:
+    INTERVAL = 0.05
+
+    @pytest.fixture()
+    def interpreter(self, simple_statechart):
+        return Interpreter(simple_statechart)
+
+    @pytest.fixture()
+    def runner(self, interpreter):
+        r = AsyncRunner(interpreter, interval=self.INTERVAL)
+        yield r
+        r.stop()
+
+    @pytest.fixture()
+    def mocked_runner(self, interpreter, mocker):
+        class MockedRunner(AsyncRunner):
+            before_run = mocker.MagicMock()
+            before_execute = mocker.MagicMock()
+            after_execute = mocker.MagicMock()
+            after_run = mocker.MagicMock()
+        
+        r = MockedRunner(interpreter, interval=self.INTERVAL)
+        yield r
+        r.stop()
+        
+    def test_not_yet_started(self, runner):
+        assert runner.interpreter.configuration == []
+
+        runner.interpreter.queue('goto s2')
+        sleep(self.INTERVAL * 2)
+        assert runner.interpreter.configuration == []
+
+        runner.start()
+        sleep(self.INTERVAL * 2)
+        assert runner.interpreter.configuration == ['root', 's3']
+
+    def test_start(self, runner):
+        runner.start()
+        sleep(self.INTERVAL * 2)
+        assert runner.interpreter.configuration == ['root', 's1']
+        
+        runner.interpreter.queue('goto s2')
+        sleep(self.INTERVAL * 2)
+        assert runner.interpreter.configuration == ['root', 's3']
+
+
+    def test_restart_stopped(self, runner):
+        runner.start()
+        runner.stop()
+
+        with pytest.raises(RuntimeError, match='Cannot restart'):
+            runner.start()
+        
+        assert not runner.running
+
+    def test_start_again(self, runner):
+        runner.start()
+
+        with pytest.raises(RuntimeError, match='already started'):
+            runner.start()
+        
+        assert runner.running
+        runner.stop()
+        assert not runner.running
+
+    def test_hooks(self, mocked_runner):
+        mocked_runner.start()
+        sleep(self.INTERVAL * 2)
+        with pytest.raises(AssertionError, message='before_run not called'):
+            mocked_runner.before_run.assert_not_called()
+
+        mocked_runner.pause()
+        mocked_runner.unpause()
+        sleep(self.INTERVAL * 2)
+        mocked_runner.pause()
+
+        with pytest.raises(AssertionError, message='before_execute not called'):
+            mocked_runner.before_execute.assert_not_called()
+
+        with pytest.raises(AssertionError, message='after_execute not called'):
+            mocked_runner.after_execute.assert_not_called()
+
+        mocked_runner.stop()
+        sleep(self.INTERVAL * 2)
+        with pytest.raises(AssertionError, message='after_run not called'):
+            mocked_runner.after_run.assert_not_called()
+            
+    def test_final(self, runner):
+        runner.start()
+        runner.interpreter.queue('goto s2')
+        runner.interpreter.queue('goto final')
+        sleep(self.INTERVAL * 2)
+        assert runner.interpreter.final
+        assert not runner.running
+        sleep(self.INTERVAL)  # Wait for the thread to finish
+        assert not runner._thread.isAlive()
+
+    def test_pause(self, runner):
+        runner.start()
+        assert not runner.paused
+
+        sleep(self.INTERVAL * 2)
+        runner.pause()
+        assert runner.paused
+        assert runner.running
+        assert runner.interpreter.configuration == ['root', 's1']
+        
+        runner.interpreter.queue('goto s2')
+        sleep(self.INTERVAL * 2)
+        assert runner.interpreter.configuration == ['root', 's1']
+
+        runner.unpause()
+        assert not runner.paused
+        assert runner.running
+        sleep(self.INTERVAL * 2)
+        assert runner.interpreter.configuration == ['root', 's3']
+
+        
+    def test_state(self, runner):
+        assert not runner.running
+        assert not runner.paused
+        runner.start()
+        assert runner.running
+        assert not runner.paused
+        runner.pause()
+        assert runner.running
+        assert runner.paused
+        runner.unpause()
+        assert runner.running
+        assert not runner.paused
+        runner.stop()
+        assert not runner.running
+        assert not runner.paused
+
+    def test_join_stopped(self, runner):
+        runner.start()
+        runner.stop()
+        runner.wait()


### PR DESCRIPTION
This PR merely replaces `run_in_background` helper and introduces a new `runner` module with an `AsyncRunner` class that can be used to run an interpreter asynchronously. 

Here's the docstring of the runner: 

```python
    """
    An asynchronous runner that repeatedly execute given interpreter.

    The runner tries to call its `execute` method every `interval` seconds, assuming 
    that a call to interpreter `execute` method takes less time than `interval`. 
    If not, subsequent call is queued and will occur as soon as possible with
    no delay. The runner stops as soon as the underlying interpreter reaches 
    a final configuration.

    The execution must be started with the `start` method, and can be (definitively)
    stopped with the `stop` method. An execution can be temporarily suspended 
    using the `pause` and `unpause` methods. A call to `wait` blocks until 
    the statechart reaches a final configuration. 

    The current state of a runner can be obtained using its `running` and 
    `paused` properties.

    While this runner can be used "as is", it was designed to be subclassed and 
    as such, proposes several hooks to control the execution and additional 
    behaviours:

     - before_run: called (only once !) when the runner is started.
     - after_run: called (only once !) when the interpreter reaches a final configuration.
       configuration of the underlying interpreter is reached. 
     - execute: called at each step of the run. By default, call the `execute()`
       method of the underlying interpreter. 
     - before_execute: called right before the call to `execute()`;
     - after_execute: called right after the call to `execute()`.
       This method is called with the returned value of `execute()`.
       
    :param interpreter: interpreter instance to run.
    :param interval: interval between two calls to `execute`
    """
```
