### PR TITLE
Support for queuing delayed events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
    ``Clock`` instances are used by the interpreter to get the current time during execution. 
    See documentation for more information.
  - (Added) An ``Interpreter.clock`` attribute that stores an instance of the newly added ``Clock`` class. 
+ - (Added) Events sent to an interpreter can be delayed with `interpreter.queue(..., delay=delay)`.
  - (Changed) ``interpreter.time`` represents the time of the last executed step, not the current
    time. Use ``interpreter.clock.time`` instead. 
  - (Changed) ``helpers.run_in_background`` no longer synchronizes the interpreter clock. 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,9 +13,14 @@ Unreleased
    ``Clock`` instances are used by the interpreter to get the current time during execution. 
    See documentation for more information.
  - (Added) An ``Interpreter.clock`` attribute that stores an instance of the newly added ``Clock`` class. 
- - (Added) Events sent to an interpreter can be delayed with `interpreter.queue(..., delay=delay)`.
+ - (Added) Delayed events are supported through ``DelayedEvent`` and ``DelayedInternalEvent``. If 
+   a delayed event with delay *d* is queued or sent by an interpreter at time *t*, it will not be processed 
+   unless `execute` or `execute_once` is called after the current clock exceeds *t + d*.
+ - (Added) Property statecharts receive a *delayed event sent* meta-event when a delayed event is sent by a statechart.
+ - (Added) Delayed events can be sent from within a statechart by specifying a ``delay`` parameter to the ``sent`` function.
  - (Changed) ``interpreter.time`` represents the time of the last executed step, not the current
    time. Use ``interpreter.clock.time`` instead. 
+ - (Changed) ``Interpreter.queue`` does not longer accept ``InternalEvent``.
  - (Changed) ``helpers.run_in_background`` no longer synchronizes the interpreter clock. 
    Use the ``start()`` method of ``interpreter.clock`` or an ``UtcClock`` instance instead. 
  - (Fixed) State *on entry* time (used for ``idle`` and ``after``) is set after the *on entry* 

--- a/docs/communication.rst
+++ b/docs/communication.rst
@@ -82,9 +82,9 @@ is sent both to ``interpreter_1`` and ``interpreter_2``.
     # Manually create and raise an internal event
     interpreter_3._raise_event(InternalEvent('test'))
 
-    print('Events for interpreter_1:', interpreter_1._external_events.pop())
-    print('Events for interpreter_2:', interpreter_2._external_events.pop())
-    print('Events for interpreter_3:', interpreter_3._internal_events.pop())
+    print('Events for interpreter_1:', interpreter_1._select_event(consume=False))
+    print('Events for interpreter_2:', interpreter_2._select_event(consume=False))
+    print('Events for interpreter_3:', interpreter_3._select_event(consume=False))
 
 .. testoutput:: bind
 
@@ -129,21 +129,23 @@ are automatically propagated to ``elevator``:
 
 .. testcode:: buttons
 
-    print('Awaiting events in buttons:', list(buttons._external_events))  # Empty
+    print('Awaiting event in buttons:', buttons._select_event(consume=False))  # None
     buttons.queue(Event('button_2_pushed'))
 
-    print('Awaiting events in buttons:', list(buttons._external_events))  # External event
+    print('Awaiting event in buttons:', buttons._select_event(consume=False))  # External event
+    print('Awaiting event in elevator:', elevator._select_event(consume=False))  # None
 
     buttons.execute(max_steps=2)  # (1) initialize buttons, and (2) consume button_2_pushed
-    print('Awaiting events in buttons:', list(buttons._internal_events))
-    print('Awaiting events in elevator:', list(elevator._external_events))
+    print('Awaiting event in buttons:', buttons._select_event(consume=False))  # Internal event 
+    print('Awaiting event in elevator:', elevator._select_event(consume=False))  # External event
 
 .. testoutput:: buttons
 
-    Awaiting events in buttons: []
-    Awaiting events in buttons: [Event('button_2_pushed')]
-    Awaiting events in buttons: [InternalEvent('floorSelected', floor=2)]
-    Awaiting events in elevator: [Event('floorSelected', floor=2)]
+    Awaiting event in buttons: None
+    Awaiting event in buttons: Event('button_2_pushed')
+    Awaiting event in elevator: None
+    Awaiting event in buttons: InternalEvent('floorSelected', floor=2)
+    Awaiting event in elevator: Event('floorSelected', floor=2)
 
 The execution of bound statecharts does not differ from the execution of unbound statecharts:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ Sismic statecharts provides full support for the majority of the UML 2 statechar
 - state transitions, guarded transitions, automatic (eventless) transitions, internal transitions and transition priorities
 - statechart variables and their initialisation
 - state entry and exit actions, transition actions
-- internal and external parametrized events
+- internal and external events, parametrized events, delayed events
 
 
 .. toctree::

--- a/docs/time.rst
+++ b/docs/time.rst
@@ -316,15 +316,43 @@ time value exceeds ``T + D``.
 Delayed events can be created using the :py:class:`~sismic.model.DelayedEvent` class 
 by providing a ``delay`` parameter:
 
---- EXAMPLE to create delayed event
+.. testcode:: delayed
 
-The following example shows that delayed events are not directly processed by an interpreter:
 
-... ex 
+    from sismic.io import import_from_yaml
+    from sismic.interpreter import Interpreter, Event, DelayedEvent
+
+    statechart = import_from_yaml(filepath='examples/elevator/elevator.yaml')
+    interpreter = Interpreter(statechart)
+
+    interpreter.queue(DelayedEvent('floorSelected', floor=4, delay=5))
+
+
+Delayed events are not processed by the interpreter, as long as the current clock
+as not reach given delay. 
+
+.. testcode:: delayed
+
+    print('Current time:', interpreter.clock.time)  # 0
+    interpreter.execute()  
+    print('Current floor:', interpreter.context['current'])  # Still on ground floor
+
+.. testoutput:: delayed
+
+    Current time: 0
+    Current floor: 0
 
 They are processed as soon as the clock time value exceeds the expected delay:
 
-... ex 
+.. testcode:: delayed
+
+    interpreter.clock.time = 5
+    interpreter.execute()
+    print('Current floor:', interpreter.context['current'])  # Still on ground floor
+
+.. testoutput:: delayed
+
+    Current floor: 4
 
 
 Notice that the time when a delayed event will be processed is based on the time value of 
@@ -332,5 +360,26 @@ the clock when the :py:meth:`~sismic.interpreter.Interpreter.queue` method is ca
 the :py:attr:`~sismic.interpreter.Interpreter.time` attribute that corresponds to the time of 
 the last executed step.
 
-... ex 
+.. testcode:: delayed
 
+    interpreter.clock.time = 6
+    print('Interpreter time:', interpreter.time)
+    print('Clock time:', interpreter.clock.time)
+    
+    interpreter.queue(DelayedEvent('floorSelected', floor=2, delay=1))
+    
+.. testoutput:: delayed
+
+    Interpreter time: 5
+    Clock time: 6
+    
+.. testcode:: delayed
+
+    interpreter.clock.time = 7
+    interpreter.execute()  # Event is processed, because 6 + 1 <= 7
+
+    print('Current floor:', interpreter.context['current'])    
+
+.. testoutput:: delayed
+
+    Current floor: 2

--- a/docs/time.rst
+++ b/docs/time.rst
@@ -1,5 +1,5 @@
 Dealing with time
-=================
+#################
 
 It is quite usual in statecharts to find notations such as "*after 30 seconds*", often expressed as specific events
 on a transition. Sismic does not support the use of these *special events*, and proposes instead to deal with time
@@ -17,6 +17,9 @@ Similarly, ``idle(x)`` evaluates to ``True`` if no transition was triggered duri
 
 These two predicates rely on the :py:attr:`~sismic.interpreter.Interpreter.time` attribute of an interpreter.
 The value of that attribute is computed at the beginning of each executed step based on a clock. 
+
+Interpreter clock
+=================
 
 Sismic provides three implementations of :py:class:`~sismic.clock.Clock` in its :py:mod:`sismic.clock` module.
 The first one is a :py:class:`~sismic.clock.SimulatedClock` that can be manually or automatically incremented. In the latter case, 
@@ -297,4 +300,37 @@ Simply subclass the :py:class:`~sismic.clock.Clock` base class.
     :members:
     :member-order: bysource
     :noindex:
+
+
+
+Delayed events
+==============
+
+Sismic also provides support for delayed events. 
+
+When a delayed event is queued in an interpreter at time ``T`` with delay ``D``, 
+it is not processed by a call to :py:meth:`~sismic.interpreter.Interpreter.execute` 
+or to :py:meth:`~sismic.interpreter.Interpreter.execute_once` unless the current clock 
+time value exceeds ``T + D``. 
+
+Delayed events can be created using the :py:class:`~sismic.model.DelayedEvent` class 
+by providing a ``delay`` parameter:
+
+--- EXAMPLE to create delayed event
+
+The following example shows that delayed events are not directly processed by an interpreter:
+
+... ex 
+
+They are processed as soon as the clock time value exceeds the expected delay:
+
+... ex 
+
+
+Notice that the time when a delayed event will be processed is based on the time value of 
+the clock when the :py:meth:`~sismic.interpreter.Interpreter.queue` method is called, not 
+the :py:attr:`~sismic.interpreter.Interpreter.time` attribute that corresponds to the time of 
+the last executed step.
+
+... ex 
 

--- a/sismic/clock/clock.py
+++ b/sismic/clock/clock.py
@@ -1,6 +1,5 @@
 import abc
 
-from numbers import Number
 from time import time
 
 
@@ -15,7 +14,7 @@ class Clock(metaclass=abc.ABCMeta):
     to get the current time during the execution of a statechart. 
     """
     @abc.abstractproperty
-    def time(self) -> Number:
+    def time(self) -> float:
         """
         Current time
         """
@@ -36,7 +35,7 @@ class SimulatedClock(Clock):
     A value strictly greater than 1 increases clock speed while a value strictly 
     lower than 1 slows down the clock.
     """
-    def __init__(self):
+    def __init__(self) -> None:
         self._base = time()
         self._time = 0
         self._play = False
@@ -46,7 +45,7 @@ class SimulatedClock(Clock):
     def _elapsed(self):
         return (time() - self._base) * self._speed if self._play else 0
     
-    def start(self):
+    def start(self) -> None:
         """
         Clock will be automatically updated both based on real time and 
         its speed attribute.
@@ -55,7 +54,7 @@ class SimulatedClock(Clock):
             self._base = time()
             self._play = True
 
-    def stop(self):
+    def stop(self) -> None:
         """
         Clock won't be automatically updated. 
         """
@@ -64,7 +63,7 @@ class SimulatedClock(Clock):
             self._play = False
 
     @property
-    def speed(self):
+    def speed(self) -> float:
         """
         Speed of the current clock. Only affects time if start() is called.
         """
@@ -77,7 +76,7 @@ class SimulatedClock(Clock):
         self._speed = speed
 
     @property
-    def time(self):
+    def time(self) -> float:
         """
         Time value of this clock.
         """
@@ -117,7 +116,7 @@ class UtcClock(Clock):
     """
     
     @property
-    def time(self):
+    def time(self) -> float:
         return time()
 
 
@@ -131,9 +130,9 @@ class SynchronizedClock(Clock):
 
     :param interpreter: an interpreter instance
     """
-    def __init__(self, interpreter):
+    def __init__(self, interpreter) -> None:
         self._interpreter = interpreter
 
     @property
-    def time(self):
+    def time(self) -> float:
         return self._interpreter.time

--- a/sismic/code/python.py
+++ b/sismic/code/python.py
@@ -73,7 +73,8 @@ class PythonEvaluator(Evaluator):
           that makes use of this evaluator.
     - On code execution:
         - A *send(name: str, **kwargs) -> None* function that takes an event name and additional keyword parameters and
-          raises an internal event with it.
+          raises an internal event with it. Raised events are propagated to bound statecharts as external events and 
+          to the current statechart as internal event. 
         - A *notify(name: str, **kwargs) -> None* function that takes an event name and additional keyword parameters and
           raises a meta-event with it. Meta-events are only sent to bound property statecharts.
         - If the code is related to a transition, the *event: Event* that fires the transition is exposed.

--- a/sismic/interpreter/__init__.py
+++ b/sismic/interpreter/__init__.py
@@ -1,4 +1,4 @@
 from .default import Interpreter
-from ..model.events import Event, InternalEvent, MetaEvent
+from ..model.events import Event, InternalEvent, MetaEvent, DelayedEvent, DelayedInternalEvent
 
-__all__ = ['Interpreter', 'Event', 'InternalEvent', 'MetaEvent']
+__all__ = ['Interpreter', 'Event', 'InternalEvent',  'DelayedEvent', 'DelayedInternalEvent', 'MetaEvent']

--- a/sismic/interpreter/default.py
+++ b/sismic/interpreter/default.py
@@ -1,6 +1,5 @@
 import warnings
 
-from numbers import Number
 from collections import deque, defaultdict
 from itertools import combinations
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Set, Union, cast, Tuple
@@ -90,7 +89,7 @@ class Interpreter:
         self._evaluator.execute_statechart(statechart)
 
     @property
-    def time(self) -> Number:
+    def time(self) -> float:
         """
         Time of the latest execution.
         """

--- a/sismic/model/events.py
+++ b/sismic/model/events.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-__all__ = ['Event', 'InternalEvent', 'MetaEvent']
+__all__ = ['Event', 'InternalEvent', 'DelayedEvent', 'DelayedInternalEvent', 'MetaEvent']
 
 
 class Event:
@@ -58,6 +58,37 @@ class InternalEvent(Event):
     Subclass of Event that represents an internal event.
     """
     pass
+
+
+class DelayedEvent(Event):
+    """
+    Event that is delayed.
+    """
+    
+    __slots__ = ['name', 'delay', 'data']
+
+    def __init__(self, name: str, delay: float, **additional_parameters: Any) -> None:
+        super().__init__(name, **additional_parameters)
+        self.delay = delay
+
+    def __getstate__(self):
+        # For pickle and implicitly for multiprocessing
+        return self.name, self.delay, self.data
+
+    def __setstate__(self, state):
+        # For pickle and implicitly for multiprocessing
+        self.name, self.delay, self.data = state
+
+    def __dir__(self):
+        return ['name', 'delay'] + list(self.data.keys())    
+
+
+class DelayedInternalEvent(InternalEvent, DelayedEvent):
+    """
+    Internal event that is delayed.
+    """
+    def __init__(self, name: str, delay: float, **additional_parameters: Any) -> None:
+        DelayedEvent.__init__(self, name, delay, **additional_parameters)
 
 
 class MetaEvent(Event):

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -3,7 +3,7 @@ import pytest
 from sismic import code
 from sismic.code.python import FrozenContext
 from sismic.exceptions import CodeEvaluationError
-from sismic.interpreter import Event, InternalEvent, MetaEvent
+from sismic.interpreter import Event, InternalEvent, DelayedInternalEvent, MetaEvent
 
 
 def test_dummy_evaluator(mocker):
@@ -80,6 +80,13 @@ class TestPythonEvaluator:
     def test_send(self, evaluator):
         events = evaluator._execute_code('send("hello")')
         assert events == [InternalEvent('hello')]
+
+    def test_send_with_delay(self, evaluator):
+        events = evaluator._execute_code('send("hello", delay=5)')
+        event = events[0]
+        assert isinstance(event, DelayedInternalEvent)
+        assert event.delay == 5
+        assert event.name == 'hello'
 
     def test_notify(self, evaluator):
         events = evaluator._execute_code('notify("hello", x=1, y="world")')


### PR DESCRIPTION
This PR adds support for queuing delayed events. 

Events can be delayed when they are added with `interpreter.queue` method. The delay is relative to the current `clock.time` value, and are processed relatively to `interpreter.time` (which coincides with `clock.time` when `execute` or `execute_once` is called). 

Things to do/consider:
 - Priority for internal event (vs. external ones) was easy to change in previous implementation. Now, it requires more changes if one wants to subclass `Interpreter`. We should see if we can bring support for delayed events while having an easy way to support other semantics. 
 - Events that are sent from within the statechart cannot (yet) be delayed. There are many issues that should be resolved first:
    - `send` should accept a `delay` parameter, but `delay` could conflict with a event parameter name.
    - How to properly propagate events to bound statecharts? Should they be considered as delayed as well for those statecharts? Should a property statechart receive a Meta-event when a delayed event is sent (regardless of its delay), or after the delay? Should we add a new function in a `PythonEvaluator` to only send (delayed) events internally?
    - Callables bound using `interpreter.bind` are not expected to accept a `delay` parameter. Should we break this? Should we create a new `DelayedEvent` class? This could have a lot of consequences on Sismic's internals.

Having the ability to send delayed events from within a statechart could be very interesting, because it means a state can `send('e', source='name', delay=5)` and have a transition stating `e [event.source == 'name']`. This means we will be able to approximate the current behaviour of `after(5)` and/or `idle(5)` (not completely, though) with events. As a consequence, and considering that delayed events are dealt with a priority queue, we will be able to execute the interpreter based on the next available event (and thus, we will have support for discrete event-based simulation). 