### PR TITLE
Add memory as a field for state in schema

### DIFF
--- a/sismic/io/yaml.py
+++ b/sismic/io/yaml.py
@@ -34,6 +34,7 @@ class SCHEMA:
         schema.Optional('initial'): schema.Use(str),
         schema.Optional('parallel states'): [state],
         schema.Optional('states'): [state],
+        schema.Optional('memory'): schema.Use(str),
     })
 
     statechart = {


### PR DESCRIPTION
I was trying to add a memory field to a history state when I encountered a validation error. The fix was trivial though. 