### PR TITLE
PlantUML: add arrow from history to initial memory

### DIFF
--- a/sismic/io/plantuml.py
+++ b/sismic/io/plantuml.py
@@ -2,7 +2,7 @@ import argparse
 import re
 import sys
 
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple, Union
 from ..io import import_from_yaml
 from ..model import (
     DeepHistoryState, FinalState, Transition, CompoundState,
@@ -170,6 +170,9 @@ class PlantUMLExporter:
 
         self.export_transitions(name)
 
+        if isinstance(state, (ShallowHistoryState, DeepHistoryState)):
+            self.export_history_memory(state)
+
         # Nested states
         for i, child in enumerate(self.statechart.children_for(name)):
             if i != 0 and isinstance(state, OrthogonalState):
@@ -225,6 +228,16 @@ class PlantUMLExporter:
             target=target_name,
             text=''.join(text),
         ))
+
+    def export_history_memory(self, history_state: Union[ShallowHistoryState, DeepHistoryState]):
+        if history_state.memory:
+            target = self.statechart.state_for(history_state.memory)
+
+            self.output('{source} {arrow} {target}'.format(
+                source=self.state_id(history_state.name),
+                arrow=self.arrow(history_state, target),
+                target=self.state_id(target.name)
+            ))
 
     def export(self) -> str:
         self.output('@startuml')


### PR DESCRIPTION
In the style of David Harels paper Statecharts: A visual formalism for complex systems, I propose to add an unlabelled arrow from a history state to its initial memory. This allows one to read the diagram only and tell the initial memory. It does not interfere with regular transitions as history cannot have any transitions (no `TransitionStateMixin`).