### PR TITLE
Changing the initial property to conform with SCXML spec

### DIFF
--- a/docs/examples/microwave/microwave.yaml
+++ b/docs/examples/microwave/microwave.yaml
@@ -19,7 +19,6 @@ statechart:
       - name: door closed
         initial:
           target: closed without item
-          action: print("on the way to door closed without item")
         states:
           - name: closed without item
             transitions:

--- a/docs/examples/microwave/microwave.yaml
+++ b/docs/examples/microwave/microwave.yaml
@@ -6,7 +6,7 @@ statechart:
     MAXPOWER = 3  # 1200W
   root state:
     name: controller
-    initial: door closed
+
     on entry: |
       power = POWER_DEFAULT
       timer = 0
@@ -17,7 +17,9 @@ statechart:
           timer = 0
     states:
       - name: door closed
-        initial: closed without item
+        initial:
+          target: closed without item
+          action: print("on the way to door closed without item")
         states:
           - name: closed without item
             transitions:

--- a/sismic/interpreter/default.py
+++ b/sismic/interpreter/default.py
@@ -610,9 +610,12 @@ class Interpreter:
                 return MicroStep(entered_states=states_to_enter, exited_states=[leaf.name])
             elif isinstance(leaf, OrthogonalState) and self._statechart.children_for(leaf.name):
                 return MicroStep(entered_states=sorted(self._statechart.children_for(leaf.name)))
-            elif isinstance(leaf, CompoundState) and leaf.initial:
+            elif isinstance(leaf, CompoundState):
+                if leaf.initial is None:
+                    return MicroStep(entered_states=[self._statechart.children_for(leaf.name)[0]])
                 if isinstance(leaf.initial, Transition):
                     return MicroStep(entered_states=[leaf.initial.target], transition=leaf.initial)
+
                 return MicroStep(entered_states=[leaf.initial])
 
         return None

--- a/sismic/interpreter/default.py
+++ b/sismic/interpreter/default.py
@@ -611,6 +611,8 @@ class Interpreter:
             elif isinstance(leaf, OrthogonalState) and self._statechart.children_for(leaf.name):
                 return MicroStep(entered_states=sorted(self._statechart.children_for(leaf.name)))
             elif isinstance(leaf, CompoundState) and leaf.initial:
+                if isinstance(leaf.initial, Transition):
+                    return MicroStep(entered_states=[leaf.initial.target], transition=leaf.initial)
                 return MicroStep(entered_states=[leaf.initial])
 
         return None

--- a/sismic/io/datadict.py
+++ b/sismic/io/datadict.py
@@ -130,7 +130,12 @@ def _import_state_from_dict(state_d: Mapping[str, Any]) -> StateMixin:
         if substates and parallel_substates:
             raise StatechartError('{} cannot declare both a "states" and a "parallel states" property'.format(name))
         elif substates:
-            state = CompoundState(name, initial=state_d.get('initial', None), on_entry=on_entry, on_exit=on_exit)
+            initial = state_d.get('initial', None)
+            if isinstance(initial, dict):
+                initial = _import_transition_from_dict(name, initial)
+            elif initial is None:
+                initial = substates[0].get('name')
+            state = CompoundState(name, initial=initial, on_entry=on_entry, on_exit=on_exit)
         elif parallel_substates:
             state = OrthogonalState(name, on_entry=on_entry, on_exit=on_exit)
         else:

--- a/sismic/io/plantuml.py
+++ b/sismic/io/plantuml.py
@@ -162,11 +162,17 @@ class PlantUMLExporter:
                 self.output('{} : **post:** {}'.format(self.state_id(name), cond))
 
         # Transitions
-        if isinstance(state, CompoundState) and state.initial:
-            self.output('[*] {arrow} {target}'.format(
-                arrow=self.arrow(None, state.initial),
-                target=self.state_id(state.initial)
-            ))
+        if isinstance(state, CompoundState):
+            if isinstance(state.initial, Transition):
+                self.output('[*] {arrow} {target}'.format(
+                    arrow=self.arrow(None, state.initial.target),
+                    target=self.state_id(state.initial.target)
+                ))
+            elif state.initial:
+                self.output('[*] {arrow} {target}'.format(
+                    arrow=self.arrow(None, state.initial),
+                    target=self.state_id(state.initial)
+                ))
 
         self.export_transitions(name)
 

--- a/sismic/io/yaml.py
+++ b/sismic/io/yaml.py
@@ -31,7 +31,7 @@ class SCHEMA:
         schema.Optional('on exit'): schema.Use(str),
         schema.Optional('transitions'): [transition],
         schema.Optional('contract'): [contract],
-        schema.Optional('initial'): schema.Use(str),
+        schema.Optional('initial'): schema.Or(str, transition),
         schema.Optional('parallel states'): [state],
         schema.Optional('states'): [state],
     })

--- a/sismic/io/yaml.py
+++ b/sismic/io/yaml.py
@@ -13,16 +13,18 @@ __all__ = ['import_from_yaml', 'export_to_yaml']
 
 class SCHEMA:
     contract = {schema.Or('before', 'after', 'always'): schema.Use(str)}
-
-    transition = {
+    # initial transitions can't have a guard and do not need a priority
+    initial_transition = {
         schema.Optional('target'): schema.Use(str),
+        schema.Optional('action'): schema.Use(str),
+    }
+    transition = {
         schema.Optional('event'): schema.Use(str),
         schema.Optional('guard'): schema.Use(str),
-        schema.Optional('action'): schema.Use(str),
         schema.Optional('contract'): [contract],
         schema.Optional('priority'): schema.Or(schema.Use(int), 'high', 'low'),
     }
-
+    transition.update(initial_transition)
     state = dict()  # type: ignore
     state.update({
         'name': schema.Use(str),
@@ -31,7 +33,7 @@ class SCHEMA:
         schema.Optional('on exit'): schema.Use(str),
         schema.Optional('transitions'): [transition],
         schema.Optional('contract'): [contract],
-        schema.Optional('initial'): schema.Or(str, transition),
+        schema.Optional('initial'): schema.Or(str, initial_transition),
         schema.Optional('parallel states'): [state],
         schema.Optional('states'): [state],
     })

--- a/sismic/model/statechart.py
+++ b/sismic/model/statechart.py
@@ -573,11 +573,16 @@ class Statechart:
         :raise StatechartError:
         """
         for name, state in self._states.items():
-            if isinstance(state, CompoundState) and state.initial:
-                if state.initial not in self._states:
-                    raise StatechartError('Initial state {} of {} does not exist'.format(state.initial, state))
-                if state.initial not in self.children_for(name):
-                    raise StatechartError('Initial state {} of {} must be a child state'.format(state.initial, state))
+            if isinstance(state, CompoundState):
+                initial = state.initial
+
+                if isinstance(initial, Transition):
+                    pass
+                elif initial is not None:
+                    if initial not in self._states:
+                        raise StatechartError('Initial state {} of {} does not exist'.format(initial, state))
+                    if initial not in self.children_for(name):
+                        raise StatechartError('Initial state {} of {} must be a child state'.format(initial, state))
         return True
 
     def _validate_historystate_memory(self) -> bool:

--- a/sismic/model/statechart.py
+++ b/sismic/model/statechart.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from typing import Callable, Dict, Iterable, List, Optional, Union, cast
-
+import warnings
 from ..exceptions import StatechartError
 
 from .elements import (CompositeStateMixin, CompoundState, HistoryStateMixin,
@@ -583,6 +583,8 @@ class Statechart:
                         raise StatechartError('Initial state {} of {} does not exist'.format(initial, state))
                     if initial not in self.children_for(name):
                         raise StatechartError('Initial state {} of {} must be a child state'.format(initial, state))
+                elif any([name == transition.target for transition in self._transitions]):
+                    warnings.warn('Composite state {} is missing will have a default to {} as an initial state'.format(name, self.children_for(name)[0].name))
         return True
 
     def _validate_historystate_memory(self) -> bool:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -147,7 +147,6 @@ class TestExportToPlantUML:
         statechart = elevator.statechart
         with open(filepath, 'r') as f:
             p1 = f.read()
-
         assert p1 != export_to_plantuml(statechart)
         assert p1 == export_to_plantuml(statechart, based_on=p1)
         assert p1 == export_to_plantuml(statechart, based_on_filepath=filepath)

--- a/tests/yaml/composite.yaml
+++ b/tests/yaml/composite.yaml
@@ -2,10 +2,10 @@ statechart:
   name: statechart with composite states
   root state:
     name: root
-    initial: s1
     states:
       - name: s1
-        initial: s1a
+        initial:
+          target: s1a
         transitions:
         - target: s2
           event: close


### PR DESCRIPTION
So I wasn't able to create an empty pull request. Github doesn't allow pull requests when the repositories are identical. I went ahead and implemented it in a way I thought would be a good starting point. I changed two things that I'll explain below. 

1. Initial property will now take either a string or an initial transition scheme
```
    # initial transitions can't have a guard and do not need a priority
    initial_transition = {
        schema.Optional('target'): schema.Use(str),
        schema.Optional('action'): schema.Use(str),
    }
```
2. scxml allows for no initial element and no initial property to be declared. In which case it states the first child state in document order will be used. I added this as well. Just looking at the Microwave example there are several instances where the initial is the top child state in the states property thus the declaration is redundent.  

Below is the addition to the initial property.

```
...
  - name: robot
    initial: 
      target: idle
      action: stretch()
    states:
      - name: idle
...
```

I wasn't sure if we should deduce the initial child state when missing at run-time or during importing / validating.  As I will explain I took the run time approach and added a warning to the **__validate_compoundstate_initial_** function in instances where a composite state is the target of a transition yet is missing the initial property / transition declaration. This allows for exporting of PlantUML charts and YAML files without adding the initial keyword and keeping the output consistent with the input.

Alternatively we could do an un-named element under the **__states__** property as in the example below. 

```
...
states:
  - type: initial
    transition:
      target: idle
      action: print("hello from the initial state")
  - name: idle
...
 ```
I feel this is more inline with the SCXML specification however it seems similar to the transient approach I use currently as the short hand version I implemented has a little more sugar. 

