### PR TITLE
Import ABCs from collections.abc

### DIFF
--- a/sismic/code/context.py
+++ b/sismic/code/context.py
@@ -2,7 +2,7 @@ import collections
 import copy
 import warnings
 
-from typing import Optional, Union, List, Dict
+from typing import Optional, List, Dict
 
 from ..model import Event, InternalEvent, MetaEvent
 

--- a/sismic/code/context.py
+++ b/sismic/code/context.py
@@ -147,7 +147,7 @@ class EventContextProvider:  # pragma: no cover
             self.pending = []
 
 
-class FrozenContext(collections.Mapping):  # pragma: no cover
+class FrozenContext(collections.abc.Mapping):  # pragma: no cover
     """
     A shallow copy of a context. The keys of the underlying context are
     exposed as attributes.

--- a/sismic/code/python.py
+++ b/sismic/code/python.py
@@ -12,7 +12,7 @@ from ..model import Event, InternalEvent, MetaEvent, Transition
 __all__ = ['PythonEvaluator']
 
 
-class FrozenContext(collections.Mapping):
+class FrozenContext(collections.abc.Mapping):
     """
     A shallow copy of a context. The keys of the underlying context are
     exposed as attributes.


### PR DESCRIPTION
This silences a python deprecation warning which can be reproduced with 

```console
$ python -Wall -c "import sismic.code"
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  class FrozenContext(collections.Mapping)
```