### PR TITLE
Improve typing for import_from_yaml and export_to_yaml

### DIFF
--- a/sismic/io/plantuml.py
+++ b/sismic/io/plantuml.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import re
 import sys
 
@@ -259,10 +260,10 @@ class PlantUMLExporter:
 
 def export_to_plantuml(
         statechart: Statechart,
-        filepath: str = None,
+        filepath: Union[str, bytes, os.PathLike] = None,
         *,
         based_on: str = None,
-        based_on_filepath: str = None,
+        based_on_filepath: Union[str, bytes, os.PathLike] = None,
         statechart_name: bool = True,
         statechart_description: bool = False,
         statechart_preamble: bool = False,

--- a/sismic/io/yaml.py
+++ b/sismic/io/yaml.py
@@ -1,7 +1,9 @@
 import ruamel.yaml as yaml
 import schema
 
+import os
 from io import StringIO
+from typing import Union
 
 from ..exceptions import StatechartError
 from ..model import Statechart
@@ -48,7 +50,7 @@ class SCHEMA:
 
 
 def import_from_yaml(
-        text: str = None, filepath: str = None, *, ignore_schema: bool = False,
+        text: str = None, filepath: Union[str, bytes, os.PathLike] = None, *, ignore_schema: bool = False,
         ignore_validation: bool = False) -> Statechart:
     """
     Import a statechart from a YAML representation (first argument) or a YAML file (filepath
@@ -89,7 +91,7 @@ def import_from_yaml(
     return sc
 
 
-def export_to_yaml(statechart: Statechart, filepath: str = None) -> str:
+def export_to_yaml(statechart: Statechart, filepath: Union[str, bytes, os.PathLike] = None) -> str:
     """
     Export given *Statechart* instance to YAML. Its YAML representation is returned by
     this function. Automatically save the output to filepath, if provided.


### PR DESCRIPTION
Hi, thanks for the great library.

I regularly need to send `pathlike.Path` objects to the `filepath` parameter of `import_from_yaml`. It _does_ already work correctly because `filepath` is simply forwarded to `open`, but it breaks the typing, forcing me to either use `#type: ignore` or to convert the path to a string explicitly, which becomes a bit noisy when there's many occurrences.

This MR changes the expected type of `filepath` from `str` to `Union[str, bytes, os.PathLike]`, mirroring what `open` accepts.

I modified `export_to_yaml` as a drive-by fix for consistency, since it also just forwards its parameter to `open`.