### PR TITLE
Replace features deprecated in Python 3.9

### DIFF
--- a/sismic/bdd/wrappers.py
+++ b/sismic/bdd/wrappers.py
@@ -2,7 +2,8 @@ import os
 import shutil
 import tempfile
 
-from typing import Union, List, Callable
+from collections.abc import Callable
+from typing import Union
 from behave import given, when, then
 from behave.__main__ import run_behave
 from behave.configuration import Configuration
@@ -14,7 +15,7 @@ from ..model import Statechart
 __all__ = ['map_action', 'map_assertion', 'execute_bdd']
 
 
-def map_action(step_text: str, existing_step_or_steps: Union[str, List[str]]) -> None:
+def map_action(step_text: str, existing_step_or_steps: Union[str, list[str]]) -> None:
     """
     Map new "given"/"when" steps to one or many existing one(s).
     Parameters are propagated to the original step(s) as well, as expected.
@@ -41,7 +42,7 @@ def map_action(step_text: str, existing_step_or_steps: Union[str, List[str]]) ->
         context.execute_steps('When ' + existing_step_or_steps.format(**kwargs))
 
 
-def map_assertion(step_text: str, existing_step_or_steps: Union[str, List[str]]) -> None:
+def map_assertion(step_text: str, existing_step_or_steps: Union[str, list[str]]) -> None:
     """
     Map a new "then" step to one or many existing one(s).
     Parameters are propagated to the original step(s) as well, as expected.
@@ -62,13 +63,13 @@ def map_assertion(step_text: str, existing_step_or_steps: Union[str, List[str]])
 
 
 def execute_bdd(statechart: Statechart,
-                feature_filepaths: List[str],
+                feature_filepaths: list[str],
                 *,
-                step_filepaths: List[str] = None,
-                property_statecharts: List[Statechart] = None,
+                step_filepaths: list[str] = None,
+                property_statecharts: list[Statechart] = None,
                 interpreter_klass: Callable[[Statechart], Interpreter] = Interpreter,
                 debug_on_error: bool = False,
-                behave_parameters: List[str] = None) -> int:
+                behave_parameters: list[str] = None) -> int:
     """
     Execute BDD tests for a statechart.
 

--- a/sismic/clock/clock.py
+++ b/sismic/clock/clock.py
@@ -13,7 +13,8 @@ class Clock(metaclass=abc.ABCMeta):
     The purpose of a clock instance is to provide a way for the interpreter
     to get the current time during the execution of a statechart.
     """
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def time(self) -> float:
         """
         Current time

--- a/sismic/code/context.py
+++ b/sismic/code/context.py
@@ -2,7 +2,7 @@ import collections
 import copy
 import warnings
 
-from typing import Optional, List, Dict
+from typing import Optional
 
 from ..model import Event, InternalEvent, MetaEvent
 
@@ -24,10 +24,10 @@ class TimeContextProvider:  # pragma: no cover
     """
 
     def __init__(self) -> None:
-        self._entry_time = dict()  # type: Dict[str, float]
-        self._idle_time = dict()  # type: Dict[str, float]
+        self._entry_time = dict()  # type: dict[str, float]
+        self._idle_time = dict()  # type: dict[str, float]
         self._time = 0  # type: float
-        self._configuration = []  # type: List[str]
+        self._configuration = []  # type: list[str]
 
     @property
     def time(self) -> float:
@@ -95,8 +95,8 @@ class EventContextProvider:  # pragma: no cover
     """
 
     def __init__(self) -> None:
-        self.pending = []  # type: List[Event]
-        self._sent = []  # type: List[Event]
+        self.pending = []  # type: list[Event]
+        self._sent = []  # type: list[Event]
         self._consumed = None  # type: Optional[Event]
 
     def send(self, name: str, **kwargs) -> None:
@@ -156,7 +156,7 @@ class FrozenContext(collections.abc.Mapping):  # pragma: no cover
     """
     __slots__ = ['__frozencontext']
 
-    def __init__(self, context: Dict) -> None:
+    def __init__(self, context: dict) -> None:
         self.__frozencontext = {k: copy.copy(v) for k, v in context.items()}
 
     def __getattr__(self, item):

--- a/sismic/code/dummy.py
+++ b/sismic/code/dummy.py
@@ -1,4 +1,4 @@
-from typing import List, Mapping
+from collections.abc import Mapping
 
 from .evaluator import Evaluator
 from ..model import Event
@@ -21,5 +21,5 @@ class DummyEvaluator(Evaluator):
     def _evaluate_code(self, code: str, *, additional_context: Mapping = None) -> bool:
         return True
 
-    def _execute_code(self, code: str, *, additional_context: Mapping = None) -> List[Event]:
+    def _execute_code(self, code: str, *, additional_context: Mapping = None) -> list[Event]:
         return []

--- a/sismic/code/evaluator.py
+++ b/sismic/code/evaluator.py
@@ -1,5 +1,6 @@
 import abc
-from typing import Any, Optional, Iterable, List, Mapping
+from collections.abc import Iterable, Mapping
+from typing import Any, Optional
 
 from ..model import Statechart, StateMixin, Transition, Event
 from ..exceptions import CodeEvaluationError
@@ -50,7 +51,7 @@ class Evaluator(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def _execute_code(
-            self, code: str, *, additional_context: Mapping[str, Any] = None) -> List[Event]:
+            self, code: str, *, additional_context: Mapping[str, Any] = None) -> list[Event]:
         """
         Generic method to execute a piece of code. This method is a fallback if one
         of the other execute_* methods is not overridden.
@@ -86,7 +87,7 @@ class Evaluator(metaclass=abc.ABCMeta):
             return self._evaluate_code(transition.guard, additional_context={'event': event})
         return None
 
-    def execute_action(self, transition: Transition, event: Optional[Event] = None) -> List[Event]:
+    def execute_action(self, transition: Transition, event: Optional[Event] = None) -> list[Event]:
         """
         Execute the action for given transition.
         This method is called for every transition that is processed, even those with no *action*.
@@ -100,7 +101,7 @@ class Evaluator(metaclass=abc.ABCMeta):
         else:
             return []
 
-    def execute_on_entry(self, state: StateMixin) -> List[Event]:
+    def execute_on_entry(self, state: StateMixin) -> list[Event]:
         """
         Execute the on entry action for given state.
         This method is called for every state that is entered, even those with no *on_entry*.
@@ -114,7 +115,7 @@ class Evaluator(metaclass=abc.ABCMeta):
         else:
             return []
 
-    def execute_on_exit(self, state: StateMixin) -> List[Event]:
+    def execute_on_exit(self, state: StateMixin) -> list[Event]:
         """
         Execute the on exit action for given state.
         This method is called for every state that is exited, even those with no *on_exit*.

--- a/sismic/code/python.py
+++ b/sismic/code/python.py
@@ -1,8 +1,8 @@
-import collections
 import copy
 
+from collections.abc import Iterator, Mapping
 from types import CodeType
-from typing import Any, Dict, List, Optional, Mapping, Iterator
+from typing import Any, Optional
 
 from . import Evaluator
 from ..exceptions import CodeEvaluationError
@@ -12,14 +12,14 @@ from ..model import Event, InternalEvent, MetaEvent, Transition
 __all__ = ['PythonEvaluator']
 
 
-class FrozenContext(collections.abc.Mapping):
+class FrozenContext(Mapping):
     """
     A shallow copy of a context. The keys of the underlying context are
     exposed as attributes.
     """
     __slots__ = ['__frozencontext']
 
-    def __init__(self, context: Dict) -> None:
+    def __init__(self, context: dict) -> None:
         self.__frozencontext = {k: copy.copy(v) for k, v in context.items()}
 
     def __getattr__(self, item):
@@ -99,16 +99,16 @@ class PythonEvaluator(Evaluator):
     def __init__(self, interpreter=None, *, initial_context: Mapping[str, Any] = None) -> None:
         super().__init__(interpreter, initial_context=initial_context)
 
-        self._context = {}  # type: Dict[str, Any]
+        self._context = {}  # type: dict[str, Any]
         self._context.update(initial_context if initial_context else {})
         self._interpreter = interpreter
 
         # Precompiled code
-        self._evaluable_code = {}  # type: Dict[str, CodeType]
-        self._executable_code = {}  # type: Dict[str, CodeType]
+        self._evaluable_code = {}  # type: dict[str, CodeType]
+        self._executable_code = {}  # type: dict[str, CodeType]
 
         # Frozen context for __old__
-        self._memory = {}  # type: Dict[int, FrozenContext]
+        self._memory = {}  # type: dict[int, FrozenContext]
 
     @property
     def context(self) -> Mapping:
@@ -154,7 +154,7 @@ class PythonEvaluator(Evaluator):
 
     def _execute_code(
             self, code: Optional[str],
-            *, additional_context: Mapping[str, Any] = None) -> List[Event]:
+            *, additional_context: Mapping[str, Any] = None) -> list[Event]:
         """
         Execute given code using Python.
 
@@ -170,7 +170,7 @@ class PythonEvaluator(Evaluator):
             compiled_code = self._executable_code.setdefault(
                 code, compile(code, '<string>', 'exec'))
 
-        sent_events = []  # type: List[Event]
+        sent_events = []  # type: list[Event]
 
         exposed_context = {
             'active': lambda name: name in self._interpreter.configuration,

--- a/sismic/helpers.py
+++ b/sismic/helpers.py
@@ -3,8 +3,9 @@ import time
 import warnings
 
 from collections import Counter
+from collections.abc import Callable, Mapping
 from functools import wraps
-from typing import Any, Callable, List, Mapping
+from typing import Any
 
 from .interpreter import Interpreter
 from .model import MacroStep
@@ -12,7 +13,7 @@ from .model import MacroStep
 __all__ = ['log_trace', 'run_in_background', 'coverage_from_trace']
 
 
-def log_trace(interpreter: Interpreter) -> List[MacroStep]:
+def log_trace(interpreter: Interpreter) -> list[MacroStep]:
     """
     Return a list that will be populated by each value returned by the *execute_once* method
     of given interpreter.
@@ -34,7 +35,7 @@ def log_trace(interpreter: Interpreter) -> List[MacroStep]:
     return trace
 
 
-def coverage_from_trace(trace: List[MacroStep]) -> Mapping[str, Counter]:
+def coverage_from_trace(trace: list[MacroStep]) -> Mapping[str, Counter]:
     """
     Given a list of macro steps considered as the trace of a statechart execution, return *Counter*
     objects that counts the states that were entered, the states that were exited and the
@@ -64,7 +65,7 @@ def coverage_from_trace(trace: List[MacroStep]) -> Mapping[str, Counter]:
 
 def run_in_background(interpreter: Interpreter,
                       delay: float = 0.05,
-                      callback: Callable[[List[MacroStep]], Any] = None) -> threading.Thread:
+                      callback: Callable[[list[MacroStep]], Any] = None) -> threading.Thread:
     """
     Run given interpreter in background.
 

--- a/sismic/interpreter/default.py
+++ b/sismic/interpreter/default.py
@@ -1,9 +1,9 @@
 import bisect
 import warnings
 
+from collections.abc import Callable, Iterable, Mapping
 from itertools import combinations
-from typing import (Any, Callable, Dict, Iterable, List, Mapping, Optional,
-                    Set, Tuple, Union, cast)
+from typing import Any, Optional, Union, cast
 
 from .listener import InternalEventListener, PropertyStatechartListener
 from ..utilities import sorted_groupby
@@ -64,24 +64,24 @@ class Interpreter:
         self._time = self.clock.time
 
         # History states memory
-        self._memory = {}  # type: Dict[str, Optional[List[str]]]
+        self._memory = {}  # type: dict[str, Optional[list[str]]]
 
         # Set of active states
-        self._configuration = set()  # type: Set[str]
+        self._configuration = set()  # type: set[str]
 
         # Entry and idle times
-        self._entry_time = dict()  # type: Dict[str, float]
-        self._idle_time = dict()  # type: Dict[str, float]
+        self._entry_time = dict()  # type: dict[str, float]
+        self._idle_time = dict()  # type: dict[str, float]
 
         # Events sent during current macro step
-        self._sent_events = []  # type: List[Event]
+        self._sent_events = []  # type: list[Event]
 
         # Event queues
-        self._internal_queue = []  # type: List[Tuple[float, InternalEvent]]
-        self._external_queue = []  # type: List[Tuple[float, Event]]
+        self._internal_queue = []  # type: list[tuple[float, InternalEvent]]
+        self._external_queue = []  # type: list[tuple[float, Event]]
 
         # Bound listeners
-        self._listeners = []  # type: List[Callable[[MetaEvent], Any]]
+        self._listeners = []  # type: list[Callable[[MetaEvent], Any]]
 
         # Evaluator
         self._evaluator = evaluator_klass(self, initial_context=initial_context)
@@ -102,7 +102,7 @@ class Interpreter:
         self.clock.time = value  # type: ignore
 
     @property
-    def configuration(self) -> List[str]:
+    def configuration(self) -> list[str]:
         """
         List of active states names, ordered by depth. Ties are broken according to the
         lexicographic order on the state name.
@@ -260,7 +260,7 @@ class Interpreter:
             self._queue_event(event)
         return self
 
-    def execute(self, max_steps: int = -1) -> List[MacroStep]:
+    def execute(self, max_steps: int = -1) -> list[MacroStep]:
         """
         Repeatedly calls *execute_once* and return a list containing
         the returned values of *execute_once*.
@@ -347,7 +347,7 @@ class Interpreter:
         :param event: Event to queue.
         """
         if isinstance(event, InternalEvent):
-            queue = cast(List[Tuple[float, Event]], self._internal_queue)
+            queue = cast(list[tuple[float, Event]], self._internal_queue)
         else:
             queue = self._external_queue
 
@@ -389,7 +389,7 @@ class Interpreter:
         :return: An instance of Event or None if no event is available
         """
         for queue in cast(
-                Tuple[List[Tuple[float, Event]]],
+                tuple[list[tuple[float, Event]]],
                 (self._internal_queue, self._external_queue)):
             if len(queue) > 0:
                 time, event = queue[0]
@@ -400,7 +400,7 @@ class Interpreter:
         return None
 
     def _select_transitions(self, event: Optional[Event], states: Iterable[str], *,
-                            eventless_first=True, inner_first=True) -> List[Transition]:
+                            eventless_first=True, inner_first=True) -> list[Transition]:
         """
         Select and return the transitions that are triggered, based on given event
         (or None if no event can be consumed) and given list of states.
@@ -414,9 +414,9 @@ class Interpreter:
         :param inner_first: True to follow inner-first/source state semantics.
         :return: list of triggered transitions.
         """
-        selected_transitions = []  # type: List[Transition]
-        considered_transitions = []  # type: List[Transition]
-        _state_depth_cache = dict()  # type: Dict[str, int]
+        selected_transitions = []  # type: list[Transition]
+        considered_transitions = []  # type: list[Transition]
+        _state_depth_cache = dict()  # type: dict[str, int]
 
         # Select triggerable (based on event) transitions for considered states
         for transition in self._statechart.transitions:
@@ -434,7 +434,7 @@ class Interpreter:
             ignored_state_selector = self._statechart.ancestors_for
         else:
             ignored_state_selector = self._statechart.descendants_for
-        ignored_states = set()  # type: Set[str]
+        ignored_states = set()  # type: set[str]
 
         # Group and sort transitions based on the event
         def eventless_first_order(t):
@@ -489,7 +489,7 @@ class Interpreter:
 
         return selected_transitions
 
-    def _sort_transitions(self, transitions: List[Transition]) -> List[Transition]:
+    def _sort_transitions(self, transitions: list[Transition]) -> list[Transition]:
         """
         Given a list of triggered transitions, return a list of transitions in an order that
         represents the order in which they have to be processed.
@@ -539,7 +539,7 @@ class Interpreter:
 
         return transitions
 
-    def _compute_steps(self) -> List[MicroStep]:
+    def _compute_steps(self) -> list[MicroStep]:
         """
         Compute and returns the next steps based on current configuration
         and event queues.
@@ -573,7 +573,7 @@ class Interpreter:
         return self._create_steps(event, transitions)
 
     def _create_steps(self, event: Optional[Event],
-                      transitions: Iterable[Transition]) -> List[MicroStep]:
+                      transitions: Iterable[Transition]) -> list[MicroStep]:
         """
         Return a (possibly empty) list of micro steps. Each micro step corresponds to the process
         of a transition matching given event.
@@ -652,7 +652,7 @@ class Interpreter:
                     leaf.name) == self._statechart.root:
                 return MicroStep(exited_states=[leaf.name, cast(str, self._statechart.root)])
             if isinstance(leaf, (ShallowHistoryState, DeepHistoryState)):
-                states_to_enter = cast(List[str], self._memory.get(leaf.name, [leaf.memory]))
+                states_to_enter = cast(list[str], self._memory.get(leaf.name, [leaf.memory]))
                 states_to_enter.sort(key=lambda x: (self._statechart.depth_for(x), x))
                 return MicroStep(entered_states=states_to_enter, exited_states=[leaf.name])
             elif isinstance(leaf, OrthogonalState) and self._statechart.children_for(leaf.name):
@@ -674,7 +674,7 @@ class Interpreter:
 
         active_configuration = set(self._configuration)  # Copy
 
-        sent_events = []  # type: List[Event]
+        sent_events = []  # type: list[Event]
 
         # Exit states
         for state in exited_states:
@@ -756,7 +756,7 @@ class Interpreter:
                          entered_states=step.entered_states, exited_states=step.exited_states,
                          sent_events=sent_events)
 
-    def _stabilize(self) -> List[MicroStep]:
+    def _stabilize(self) -> list[MicroStep]:
         """
         Compute, apply and return stabilization steps.
 

--- a/sismic/interpreter/listener.py
+++ b/sismic/interpreter/listener.py
@@ -1,4 +1,5 @@
-from typing import Callable, Any
+from collections.abc import Callable
+from typing import Any
 
 from ..model import MetaEvent, Event
 

--- a/sismic/io/datadict.py
+++ b/sismic/io/datadict.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Mapping, MutableMapping, Optional, Tuple, cast
+from collections.abc import Mapping, MutableMapping
+from typing import Any, Optional, cast
 
 from ..exceptions import StatechartError
 from ..model import (ActionStateMixin, BasicState, CompositeStateMixin,
@@ -19,7 +20,7 @@ def import_from_dict(data: Mapping[str, Any]) -> Statechart:
     states = []  # (StateMixin instance, parent name)
     transitions = []  # Transition instances
     # (State dict, parent name)
-    # type: List[Tuple[Mapping[str, Any], Optional[str]]]
+    # type: list[tuple[Mapping[str, Any], Optional[str]]]
     data_to_consider = [(data['root state'], None)]
 
     while data_to_consider:

--- a/sismic/io/plantuml.py
+++ b/sismic/io/plantuml.py
@@ -2,7 +2,7 @@ import argparse
 import re
 import sys
 
-from typing import Dict, List, Tuple, Union
+from typing import Union
 from ..io import import_from_yaml
 from ..model import (
     DeepHistoryState, FinalState, Transition, CompoundState,
@@ -35,7 +35,7 @@ class PlantUMLExporter:
         self.transition_contracts = transition_contracts
         self.transition_action = transition_action
 
-        self._based_on_arrows = dict()  # type: Dict[Tuple[str, str], str]
+        self._based_on_arrows = dict()  # type: dict[tuple[str, str], str]
         if self.based_on:
             for line in self.based_on.splitlines():
                 matches = re.findall(r'(\[\*\]|[a-zA-Z0-9]+) -([^ ]*)> (\[\*\]|[a-zA-Z0-9]+)', line)
@@ -43,7 +43,7 @@ class PlantUMLExporter:
                     self._based_on_arrows[(matches[0][0], matches[0][2])
                                           ] = '-{}>'.format(matches[0][1])
 
-        self._output = []  # type: List[str]
+        self._output = []  # type: list[str]
         self._indent = 0
 
     def arrow(self, source, target):

--- a/sismic/model/elements.py
+++ b/sismic/model/elements.py
@@ -1,5 +1,4 @@
 from abc import ABCMeta
-from typing import List
 
 __all__ = ['ContractMixin', 'StateMixin', 'ActionStateMixin', 'TransitionStateMixin',
            'CompositeStateMixin', 'HistoryStateMixin', 'BasicState', 'CompoundState',
@@ -12,9 +11,9 @@ class ContractMixin(metaclass=ABCMeta):
     """
 
     def __init__(self) -> None:
-        self.preconditions = []  # type: List[str]
-        self.postconditions = []  # type: List[str]
-        self.invariants = []  # type: List[str]
+        self.preconditions = []  # type: list[str]
+        self.postconditions = []  # type: list[str]
+        self.invariants = []  # type: list[str]
 
     def __eq__(self, other):
         if isinstance(other, ContractMixin):

--- a/sismic/model/statechart.py
+++ b/sismic/model/statechart.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable, Iterable
 from copy import deepcopy
-from typing import Callable, Dict, Iterable, List, Optional, Union, cast
+from typing import Optional, Union, cast
 
 from ..exceptions import StatechartError
 
@@ -23,10 +24,10 @@ class Statechart:
         self.description = description
         self._preamble = preamble
 
-        self._states = {}  # type: Dict[str, StateMixin]
-        self._parent = {}  # type: Dict[str, Optional[str]]
-        self._children = {}  # type: Dict[Optional[str], List[str]]
-        self._transitions = []  # type: List[Transition]
+        self._states = {}  # type: dict[str, StateMixin]
+        self._parent = {}  # type: dict[str, Optional[str]]
+        self._children = {}  # type: dict[Optional[str], list[str]]
+        self._transitions = []  # type: list[Transition]
 
         self._children[None] = []  # Root state
 
@@ -85,7 +86,7 @@ class Statechart:
         except KeyError as e:
             raise StatechartError('State {} does not exist'.format(name)) from e
 
-    def children_for(self, name: str) -> List[str]:
+    def children_for(self, name: str) -> list[str]:
         """
         Return the names of the children of the given state.
 
@@ -97,7 +98,7 @@ class Statechart:
 
         return self._children[name]
 
-    def ancestors_for(self, name: str) -> List[str]:
+    def ancestors_for(self, name: str) -> list[str]:
         """
         Return an ordered list of ancestors for the given state.
         Ancestors are ordered by decreasing depth.
@@ -115,7 +116,7 @@ class Statechart:
             parent = self._parent[parent]
         return ancestors
 
-    def descendants_for(self, name: str) -> List[str]:
+    def descendants_for(self, name: str) -> list[str]:
         """
         Return an ordered list of descendants for the given state.
         Descendants are ordered by increasing depth.
@@ -168,7 +169,7 @@ class Statechart:
                 return state
         return None
 
-    def leaf_for(self, names: Iterable[str]) -> List[str]:
+    def leaf_for(self, names: Iterable[str]) -> list[str]:
         """
         Return the leaves of *names*.
 
@@ -179,7 +180,7 @@ class Statechart:
         :return: the names of the leaves in *names*
         :raise StatechartError: if a state does not exist
         """
-        leaves = []  # type: List[str]
+        leaves = []  # type: list[str]
         names = set(names)  # Lookups in set are more efficient
 
         for name in names:
@@ -272,7 +273,7 @@ class Statechart:
                 new_target_state = self.state_for(new_target)
                 transition._target = new_target_state.name
 
-    def transitions_from(self, source: str) -> List[Transition]:
+    def transitions_from(self, source: str) -> list[Transition]:
         """
         Return the list of transitions whose source is given name.
 
@@ -288,7 +289,7 @@ class Statechart:
                 transitions.append(transition)
         return transitions
 
-    def transitions_to(self, target: str) -> List[Transition]:
+    def transitions_to(self, target: str) -> list[Transition]:
         """
         Return the list of transitions whose target is given name.
         Internal transitions are returned too.
@@ -306,7 +307,7 @@ class Statechart:
                 transitions.append(transition)
         return transitions
 
-    def transitions_with(self, event: str) -> List[Transition]:
+    def transitions_with(self, event: str) -> list[Transition]:
         """
         Return the list of transitions that can be triggered by given event name.
 
@@ -321,7 +322,7 @@ class Statechart:
 
     # ######### EVENTS ##########
 
-    def events_for(self, name_or_names: Union[str, List[str]] = None) -> List[str]:
+    def events_for(self, name_or_names: Union[str, list[str]] = None) -> list[str]:
         """
         Return a list containing the name of every event that guards a transition
         in this statechart.
@@ -340,7 +341,7 @@ class Statechart:
         else:
             states = name_or_names
 
-        states = cast(List[str], states)
+        states = cast(list[str], states)
         names = set()
         for state in states:
             for transition in self.transitions_from(state):

--- a/sismic/model/steps.py
+++ b/sismic/model/steps.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from .elements import Transition
 from .events import Event
@@ -24,13 +24,13 @@ class MicroStep:
     __slots__ = ['event', 'transition', 'entered_states', 'exited_states', 'sent_events']
 
     def __init__(self, event: Event = None, transition: Transition = None,
-                 entered_states: List[str] = None, exited_states: List[str] = None,
-                 sent_events: List[Event] = None) -> None:
+                 entered_states: list[str] = None, exited_states: list[str] = None,
+                 sent_events: list[Event] = None) -> None:
         self.event = event
         self.transition = transition
-        self.entered_states = entered_states if entered_states else []  # type: List[str]
-        self.exited_states = exited_states if exited_states else []  # type: List[str]
-        self.sent_events = sent_events if sent_events else []  # type: List[Event]
+        self.entered_states = entered_states if entered_states else []  # type: list[str]
+        self.exited_states = exited_states if exited_states else []  # type: list[str]
+        self.sent_events = sent_events if sent_events else []  # type: list[Event]
 
     def __repr__(self):
         params = []
@@ -55,14 +55,14 @@ class MacroStep:
     :param steps: a list of *MicroStep* instances
     """
 
-    def __init__(self, time: float, steps: List[MicroStep]) -> None:
+    def __init__(self, time: float, steps: list[MicroStep]) -> None:
         self._time = time
         self._steps = steps
 
     __slots__ = ['_time', '_steps']
 
     @property
-    def steps(self) -> List[MicroStep]:
+    def steps(self) -> list[MicroStep]:
         """
         List of micro steps
         """
@@ -86,34 +86,34 @@ class MacroStep:
         return None
 
     @property
-    def transitions(self) -> List[Transition]:
+    def transitions(self) -> list[Transition]:
         """
         A (possibly empty) list of transitions that were triggered.
         """
         return [step.transition for step in self._steps if step.transition]
 
     @property
-    def entered_states(self) -> List[str]:
+    def entered_states(self) -> list[str]:
         """
         List of the states names that were entered.
         """
-        states = []  # type: List[str]
+        states = []  # type: list[str]
         for step in self._steps:
             states += step.entered_states
         return states
 
     @property
-    def exited_states(self) -> List[str]:
+    def exited_states(self) -> list[str]:
         """
         List of the states names that were exited.
         """
-        states = []  # type: List[str]
+        states = []  # type: list[str]
         for step in self._steps:
             states += step.exited_states
         return states
 
     @property
-    def sent_events(self) -> List[Event]:
+    def sent_events(self) -> list[Event]:
         """
         List of events that were sent during this step.
         """

--- a/sismic/runner/runner.py
+++ b/sismic/runner/runner.py
@@ -1,8 +1,6 @@
 import time
 import threading
 
-from typing import List
-
 from ..interpreter import Interpreter
 from ..model import MacroStep
 
@@ -113,7 +111,7 @@ class AsyncRunner:
         if self._thread.is_alive():
             self._thread.join()
 
-    def execute(self) -> List[MacroStep]:
+    def execute(self) -> list[MacroStep]:
         """
         Called each time the interpreter has to be executed.
         """
@@ -135,7 +133,7 @@ class AsyncRunner:
         """
         pass
 
-    def after_execute(self, steps: List[MacroStep]):
+    def after_execute(self, steps: list[MacroStep]):
         """
         Called after each call to self.execute().
         Receives the return value of self.execute().

--- a/sismic/testing.py
+++ b/sismic/testing.py
@@ -1,4 +1,5 @@
-from typing import Union, Optional, List, Any, Mapping
+from collections.abc import Mapping
+from typing import Union, Optional, Any
 from .interpreter import Interpreter
 from .model import MacroStep, Transition
 
@@ -10,7 +11,7 @@ __all__ = [
     'expression_holds',
 ]
 
-MacroSteps = Union[MacroStep, List[MacroStep]]
+MacroSteps = Union[MacroStep, list[MacroStep]]
 
 
 def state_is_entered(steps: MacroSteps, name: str) -> bool:


### PR DESCRIPTION
Hi again,

I realized that sismic officially requires at least Python 3.9, so I decided to push a new PR that replaces some of the standard library features deprecated in 3.9:
* `abc.abstractproperty` was deprecated in 3.3 because `property` and `abstractmethod` now compose as expected. It's supposed to become a noisy `DeprecationWarning` in 3.15, and to be removed in 3.21.
* `Dict`, `Tuple`, `Set` and `List` from the `typing` module are now useless: the built-in types work out of the box for type hinting. The new mechanism introduced to make built-in collections support type hinting is supposedly faster too, so that could slightly improve loading times (though it's probably lost in the noise).
* `Mapping`, `MutableMapping`, `Iterator`, `Iterable` and `Callable` from the  `typing` module are also deprecated: they are now aliases to the corresponding types in `collections.abc`, which become the preferred import for type hinting.

I did the change manually because automated tools such as Ruff were more invasive (notably shuffling your imports), though don't hesitate to tell me if you'd like to introduce configuration for some automated tooling in the project. It shouldn't be too hard to setup.